### PR TITLE
Fix GPU demo playbook in check mode

### DIFF
--- a/playbooks/demo_gpu_k8s.yml
+++ b/playbooks/demo_gpu_k8s.yml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: all:!ops-1
   become: true
   vars:
     ops_host: "127.0.0.1"

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_driver.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_driver.yml
@@ -8,6 +8,7 @@
   args:
     executable: /bin/bash
   become: true
+  when: not ansible_check_mode
 
 - name: Install NVIDIA driver and container runtime
   apt:
@@ -19,3 +20,4 @@
     state: present
     update_cache: yes
   become: true
+  when: not ansible_check_mode


### PR DESCRIPTION
## Summary
- exclude ops-1 host from GPU demo play
- skip driver installation when running in check mode

## Testing
- `ansible-playbook -i inventory/gpu_k8s_cluster playbooks/demo_gpu_k8s.yml -D -C` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685be758e5448332adcffdf6a3368119