### PR TITLE
Fix NVIDIA repo URLs for gpu role

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_driver.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_driver.yml
@@ -1,11 +1,10 @@
 - name: Add NVIDIA repositories
   shell: |
     add-apt-repository -y ppa:graphics-drivers
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
     curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | apt-key add -
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | tee /etc/apt/sources.list.d/nvidia-container-runtime.list
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | tee /etc/apt/sources.list.d/nvidia-container-runtime.list
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -
-    curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
+    curl -s -L https://nvidia.github.io/nvidia-docker/stable/ubuntu22.04/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
     apt-get update
   args:
     executable: /bin/bash


### PR DESCRIPTION
## Summary
- use stable repo URLs in gpu-k8s role to avoid unsupported distribution errors

## Testing
- `ansible-lint playbooks/roles/vhosts/gpu-k8s/tasks/install_driver.yml` *(fails: 5 violations)*

------
https://chatgpt.com/codex/tasks/task_e_685bebd8719c8332b781c3fe885fa6b0