### PR TITLE
Update gpu-k8s role to pull latest Sealos

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -11,14 +11,17 @@ The role performs four main tasks:
 3. **Verify the cluster state** after initialization, displaying the `sealos` version and the current Kubernetes nodes.
 4. **Verify GPU access** by deploying the official NVIDIA device plugin and running a small CUDA workload.
 
+When `sealos_version` is set to `latest` (the default), the role automatically
+fetches the most recent stable release from GitHub.
+
 
 The following command is used to create the cluster (example with one master and one worker):
 
 ```bash
 sealos run \
-  registry.cn-shanghai.aliyuncs.com/labring/kubernetes:v1.29.9 \
-  registry.cn-shanghai.aliyuncs.com/labring/cilium:v1.13.4 \
-  registry.cn-shanghai.aliyuncs.com/labring/helm:v3.9.4 \
+  registry.cn-shanghai.aliyuncs.com/labring/kubernetes:<latest> \
+  registry.cn-shanghai.aliyuncs.com/labring/cilium:<cilium_version> \
+  registry.cn-shanghai.aliyuncs.com/labring/helm:<helm_version> \
   --masters 172.16.11.120 \
   --nodes 172.16.11.152 \
   --env '{}' \

--- a/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
@@ -1,5 +1,5 @@
 # Default variables for gpu-k8s role
-sealos_version: v1.29.9
+sealos_version: latest
 cilium_version: v1.13.4
 helm_version: v3.9.4
 master_ips: []  # List of up to three master node IPs

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -1,6 +1,40 @@
+- name: Determine latest sealos version when requested
+  uri:
+    url: https://api.github.com/repos/labring/sealos/releases/latest
+    return_content: yes
+  register: sealos_latest
+  when: sealos_version is not defined or sealos_version == 'latest'
+
+- name: Set sealos_version fact to latest release
+  set_fact:
+    sealos_version: "{{ (sealos_latest.content | from_json).tag_name }}"
+  when: sealos_version is not defined or sealos_version == 'latest'
+
 - name: Install sealos CLI
   shell: |
-    curl -sL https://raw.githubusercontent.com/labring/sealos/main/scripts/install.sh | bash -s {{ sealos_version }}
+    VERSION={{ sealos_version }}
+    wget -q https://github.com/labring/sealos/releases/download/${VERSION}/sealos_${VERSION#v}_linux_amd64.tar.gz
+    tar -xzf sealos_${VERSION#v}_linux_amd64.tar.gz sealos
+    chmod +x sealos
+    mv sealos /usr/bin/sealos
+  args:
+    executable: /bin/bash
+  when: inventory_hostname == (ops_host | default(master_ips | first))
+
+- name: Install Helm
+  shell: |
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+    chmod 700 get_helm.sh
+    ./get_helm.sh
+    rm -f get_helm.sh
+  args:
+    executable: /bin/bash
+  when: inventory_hostname == (ops_host | default(master_ips | first)) and (ansible_facts['distribution'] == 'Ubuntu' or ansible_facts['distribution'] == 'Debian')
+
+- name: Install nerdctl
+  shell: |
+    wget -q https://github.com/containerd/nerdctl/releases/download/v2.0.2/nerdctl-2.0.2-linux-amd64.tar.gz
+    tar -C /usr/local -xzf nerdctl-2.0.2-linux-amd64.tar.gz
   args:
     executable: /bin/bash
   when: inventory_hostname == (ops_host | default(master_ips | first))


### PR DESCRIPTION
## Summary
- update `gpu-k8s` defaults to use latest Sealos
- fetch latest Sealos release dynamically
- install helm and nerdctl when bootstrapping the GPU cluster
- document the new behaviour in gpu-k8s docs

## Testing
- `ansible-playbook playbooks/demo_gpu_k8s.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf98bb1388332b19149c3aa6b0047