### PR TITLE
Fix GPU k8s role default version

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -12,14 +12,16 @@ The role performs four main tasks:
 4. **Verify GPU access** by deploying the official NVIDIA device plugin and running a small CUDA workload.
 
 When `sealos_version` is set to `latest` (the default), the role automatically
-fetches the most recent stable release from GitHub.
+fetches the most recent stable release from GitHub. The Kubernetes image tag is
+controlled separately via `kubernetes_version`, which defaults to `v1.25.16` but
+can be overridden to any compatible release.
 
 
 The following command is used to create the cluster (example with one master and one worker):
 
 ```bash
 sealos run \
-  registry.cn-shanghai.aliyuncs.com/labring/kubernetes:<latest> \
+  registry.cn-shanghai.aliyuncs.com/labring/kubernetes:<kubernetes_version> \
   registry.cn-shanghai.aliyuncs.com/labring/cilium:<cilium_version> \
   registry.cn-shanghai.aliyuncs.com/labring/helm:<helm_version> \
   --masters 172.16.11.120 \

--- a/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
@@ -1,5 +1,6 @@
 # Default variables for gpu-k8s role
 sealos_version: latest
+kubernetes_version: v1.25.16
 cilium_version: v1.13.4
 helm_version: v3.9.4
 master_ips: []  # List of up to three master node IPs

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -42,7 +42,7 @@
 - name: Run sealos to create Kubernetes cluster
   shell: |
     sealos run \
-      registry.cn-shanghai.aliyuncs.com/labring/kubernetes:{{ sealos_version }} \
+      registry.cn-shanghai.aliyuncs.com/labring/kubernetes:{{ kubernetes_version }} \
       registry.cn-shanghai.aliyuncs.com/labring/cilium:{{ cilium_version }} \
       registry.cn-shanghai.aliyuncs.com/labring/helm:{{ helm_version }} \
       --masters {{ master_ips | join(',') }} \


### PR DESCRIPTION
## Summary
- allow specifying Kubernetes version separately from sealos CLI
- default Kubernetes image to v1.25.16
- document the new variable

## Testing
- `ansible-lint` *(fails: load errors)*

------
https://chatgpt.com/codex/tasks/task_e_685bfbbeae488332908b0d5986c763d9