### PR TITLE
Implement automatic LabRing registry selection

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -18,10 +18,11 @@ fetches the most recent stable release from GitHub.
 The following command is used to create the cluster (example with one master and one worker):
 
 ```bash
+REGISTRY=$(scripts/get_labring_registry.sh)
 sealos run \
-  registry.cn-shanghai.aliyuncs.com/labring/kubernetes:<latest> \
-  registry.cn-shanghai.aliyuncs.com/labring/cilium:<cilium_version> \
-  registry.cn-shanghai.aliyuncs.com/labring/helm:<helm_version> \
+  ${REGISTRY}/kubernetes:<latest> \
+  ${REGISTRY}/cilium:<cilium_version> \
+  ${REGISTRY}/helm:<helm_version> \
   --masters 172.16.11.120 \
   --nodes 172.16.11.152 \
   --env '{}' \

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -39,12 +39,18 @@
     executable: /bin/bash
   when: inventory_hostname == (ops_host | default(master_ips | first))
 
+- name: Determine LabRing registry prefix
+  shell: "{{ role_path }}/../../../../scripts/get_labring_registry.sh"
+  register: labring_registry
+  changed_when: false
+  when: inventory_hostname == (ops_host | default(master_ips | first))
+
 - name: Run sealos to create Kubernetes cluster
   shell: |
     sealos run \
-      registry.cn-shanghai.aliyuncs.com/labring/kubernetes:{{ sealos_version }} \
-      registry.cn-shanghai.aliyuncs.com/labring/cilium:{{ cilium_version }} \
-      registry.cn-shanghai.aliyuncs.com/labring/helm:{{ helm_version }} \
+      {{ labring_registry.stdout }}/kubernetes:{{ sealos_version }} \
+      {{ labring_registry.stdout }}/cilium:{{ cilium_version }} \
+      {{ labring_registry.stdout }}/helm:{{ helm_version }} \
       --masters {{ master_ips | join(',') }} \
       --nodes {{ node_ips | join(',') }} \
       --env '{{ sealos_cmd_env }}' \

--- a/scripts/deepflow/deploy-k8s.sh
+++ b/scripts/deepflow/deploy-k8s.sh
@@ -12,8 +12,11 @@ sealos load -i sealos-helm.tar
 sealos load -i sealos-k8s-1.25.16.tar
 
 # 单机部署(单机部署无需ssh密码，root用户本机直接执行即可)
+# 根据节点 IP 所在地区自动选择拉取镜像的仓库
+REGISTRY_PREFIX=$(dirname "$0")/../get_labring_registry.sh
+REGISTRY_PREFIX=$("$REGISTRY_PREFIX")
 sealos run \
-    registry.cn-shanghai.aliyuncs.com/labring/kubernetes:v1.25.16  \
-    registry.cn-shanghai.aliyuncs.com/labring/helm:v3.9.4          \
-    registry.cn-shanghai.aliyuncs.com/labring/calico:v3.24.1       \
+    ${REGISTRY_PREFIX}/kubernetes:v1.25.16  \
+    ${REGISTRY_PREFIX}/helm:v3.9.4          \
+    ${REGISTRY_PREFIX}/calico:v3.24.1       \
     --single

--- a/scripts/get_labring_registry.sh
+++ b/scripts/get_labring_registry.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Determine the appropriate LabRing container registry based on geolocation.
+# Defaults to the Chinese mainland registry.
+REGISTRY_CN="registry.cn-shanghai.aliyuncs.com/labring"
+REGISTRY_INT="ghcr.io/labring"
+# Query external service for country code; fall back to CN on failure.
+COUNTRY=$(curl -fsSL https://ipapi.co/country/ 2>/dev/null || echo "")
+if [ "$COUNTRY" = "CN" ]; then
+  echo "$REGISTRY_CN"
+else
+  echo "$REGISTRY_INT"
+fi


### PR DESCRIPTION
## Summary
- add script `get_labring_registry.sh` to detect region and pick registry
- update GPU Kubernetes role docs to use new script
- choose registry dynamically in GPU K8s Ansible tasks
- use registry selection in DeepFlow deploy script

## Testing
- `scripts/get_labring_registry.sh`


------
https://chatgpt.com/codex/tasks/task_e_685bfcae4aa0833287a82d4f7c69be5a