### PR TITLE
Fix gpu-k8s role script path

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -43,6 +43,8 @@
   shell: "{{ role_path }}/../../../../scripts/get_labring_registry.sh"
   register: labring_registry
   changed_when: false
+  delegate_to: localhost
+  run_once: true
   when: inventory_hostname == (ops_host | default(master_ips | first))
 
 - name: Run sealos to create Kubernetes cluster


### PR DESCRIPTION
## Summary
- delegate fetching LabRing registry prefix to localhost

## Testing
- `ansible-lint playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml >/tmp/ansible-lint.log && tail -n 20 /tmp/ansible-lint.log`

------
https://chatgpt.com/codex/tasks/task_e_685c03135a9c8332b6df49dc25cab08c