### PR TITLE
Fix GPU Kubernetes IP resolution

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -20,6 +20,10 @@
       {{ (node_ips | default([])) | length > 0
          | ternary(node_ips,
                    nodes | default([]) | map('extract', hostvars, 'ansible_host') | list) }}
+  delegate_to: "{{ ops_host | default(masters | default(master_ips) | first) }}"
+  delegate_facts: true
+  run_once: true
+  become: false
 
 
 - name: Install sealos CLI


### PR DESCRIPTION
## Summary
- resolve master/node IPs on the ops host only once

## Testing
- `ansible-lint playbooks/demo_gpu_k8s.yml` *(fails: vault password file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0ef3a0fc8332965d3f83d94e9524