### PR TITLE
Fix GPU k8s ssh precheck user

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -73,7 +73,9 @@
   when: inventory_hostname == (ops_host | default(masters | default(master_ips) | first))
 
 - name: Verify passwordless SSH access to all cluster nodes
-  shell: ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@{{ item }} hostname
+  shell: >-
+    ssh -o BatchMode=yes -o StrictHostKeyChecking=no \
+    {{ ansible_ssh_user | default(ansible_user, true) | default('root') }}@{{ item }} hostname
   loop: "{{ master_ips + node_ips }}"
   delegate_to: "{{ ops_host | default(masters | default(master_ips) | first) }}"
   become: false


### PR DESCRIPTION
## Summary
- fix ssh precheck in gpu-k8s role so it uses the inventory SSH user instead of root

## Testing
- `ansible-lint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c192896ac833283092c756fad1b8d