### PR TITLE
Fix GPU k8s SSH trust

### DIFF
--- a/playbooks/demo_gpu_k8s.yml
+++ b/playbooks/demo_gpu_k8s.yml
@@ -1,7 +1,9 @@
 - hosts: all
   become: true
   vars:
-    ops_host: "127.0.0.1"
+    # Use the inventory hostname for delegation so Ansible
+    # applies the correct connection variables
+    ops_host: "ops-1"
     masters:
       - "k8s-1"
     nodes:

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -75,6 +75,7 @@
 - name: Verify passwordless SSH access to all cluster nodes
   shell: >-
     ssh -o BatchMode=yes -o StrictHostKeyChecking=no \
+    -i {{ ansible_ssh_private_key_file | default('~/.ssh/id_rsa') }} \
     {{ ansible_ssh_user | default(ansible_user, true) | default('root') }}@{{ item }} hostname
   loop: "{{ master_ips + node_ips }}"
   delegate_to: "{{ ops_host | default(masters | default(master_ips) | first) }}"


### PR DESCRIPTION
## Summary
- use inventory host name for delegation in demo playbook
- pass private key when verifying passwordless SSH access

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c1d9293408332b5378eecc801cc6b