### PR TITLE
Allow customizing SSH user for cluster setup

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -44,6 +44,18 @@ Add the role to your playbook along with the `ssh-trust` role which configures p
     - gpu-k8s
 ```
 
+By default the SSH key is created for the same user Ansible connects with. You
+can override this by setting `ssh_user`:
+
+```yaml
+- hosts: all
+  vars:
+    ssh_user: ubuntu
+  roles:
+    - ssh-trust
+    - gpu-k8s
+```
+
 
 Example playbook snippet defining the IP lists:
 

--- a/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
@@ -9,3 +9,4 @@ master_ips: []  # List of up to three master node IPs
 node_ips: []    # List of worker node IPs
 sealos_cmd_env: '{}'
 kubeadm_init_cmd: "kubeadm init --skip-phases=addon/kube-proxy"
+ssh_user: "{{ ansible_user | default('root') }}"

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -76,7 +76,7 @@
   shell: >-
     ssh -o BatchMode=yes -o StrictHostKeyChecking=no \
     -i {{ ansible_ssh_private_key_file | default('~/.ssh/id_rsa') }} \
-    {{ ansible_ssh_user | default(ansible_user, true) | default('root') }}@{{ item }} hostname
+    {{ ssh_user | default(ansible_ssh_user | default(ansible_user, true) | default('root')) }}@{{ item }} hostname
   loop: "{{ master_ips + node_ips }}"
   delegate_to: "{{ ops_host | default(masters | default(master_ips) | first) }}"
   become: false

--- a/playbooks/roles/vhosts/ssh-trust/defaults/main.yml
+++ b/playbooks/roles/vhosts/ssh-trust/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default user for generating and installing SSH key
+ssh_user: "{{ ansible_user | default('root') }}"

--- a/playbooks/roles/vhosts/ssh-trust/tasks/main.yml
+++ b/playbooks/roles/vhosts/ssh-trust/tasks/main.yml
@@ -5,6 +5,8 @@
     executable: /bin/bash
   delegate_to: "{{ ops_host }}"
   run_once: true
+  become: true
+  become_user: "{{ ssh_user }}"
 
 - name: Fetch ops host public key
   slurp:
@@ -12,8 +14,10 @@
   register: ops_pub_key
   delegate_to: "{{ ops_host }}"
   run_once: true
+  become: true
+  become_user: "{{ ssh_user }}"
 
 - name: Authorize ops host key on cluster hosts
   ansible.builtin.authorized_key:
-    user: "{{ ansible_user | default('root') }}"
+    user: "{{ ssh_user }}"
     key: "{{ ops_pub_key.content | b64decode }}"


### PR DESCRIPTION
## Summary
- add ssh_user variable to ssh-trust role
- use ssh_user in gpu-k8s passwordless SSH check
- document how to override ssh_user

## Testing
- `ansible-playbook --syntax-check playbooks/demo_gpu_k8s.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1f523184833283f2fa4742e357d5