### PR TITLE
Fix Sealos ssh flags

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -30,8 +30,8 @@ sealos run \
   --env '{}' \
   --cmd "kubeadm init --skip-phases=addon/kube-proxy"
 ```
-If deploying with a non-root user the command also requires `--ssh-user` and
-`--ssh-private-key` options pointing to the user's key.
+If deploying with a non-root user the command also requires `--user` and
+`--pk` options pointing to the user's SSH key.
 
 After the cluster is running the role installs the NVIDIA device plugin and runs a test pod to ensure `nvidia-smi` works inside the cluster.
 

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -95,8 +95,8 @@
       {{ labring_registry.stdout }}/helm:{{ helm_version }} \
       --masters {{ master_ips | join(',') }} \
       --nodes {{ node_ips | join(',') }} \
-      --ssh-user {{ ssh_user }} \
-      --ssh-private-key {{ ssh_private_key }} \
+      --user {{ ssh_user }} \
+      --pk {{ ssh_private_key }} \
       --env '{{ sealos_cmd_env }}' \
       --cmd "{{ kubeadm_init_cmd }}"
   args:


### PR DESCRIPTION
## Summary
- update usage docs for new sealos flags
- update playbook to use `--user` and `--pk` flags

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cafdb8324833297c30a1fb507958e