### PR TITLE
Add uidmap install and rootless note

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -31,7 +31,9 @@ sealos run \
   --cmd "kubeadm init --skip-phases=addon/kube-proxy"
 ```
 If deploying with a non-root user the command also requires `--user` and
-`--pk` options pointing to the user's SSH key.
+`--pk` options pointing to the user's SSH key. The host running Sealos must have
+`newuidmap` and `newgidmap` installed (typically provided by the `uidmap`
+package) to enable user namespaces.
 
 After the cluster is running the role installs the NVIDIA device plugin and runs a test pod to ensure `nvidia-smi` works inside the cluster.
 

--- a/playbooks/roles/vhosts/common/files/install-packages.sh
+++ b/playbooks/roles/vhosts/common/files/install-packages.sh
@@ -4,4 +4,4 @@ export DEBIAN_FRONTEND=noninteractive
 curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg
 sudo echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
 sudo apt-get update
-sudo apt-get install -y vault auditd
+sudo apt-get install -y vault auditd uidmap


### PR DESCRIPTION
## Summary
- install `uidmap` package so sealos rootless mode works
- document newuidmap/newgidmap requirement for gpu-k8s role

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cb3840e00833298e4d8e2b3e3c8d7