### PR TITLE
Add root_mode toggle

### DIFF
--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -31,7 +31,9 @@ sealos run \
   --cmd "kubeadm init --skip-phases=addon/kube-proxy"
 ```
 If deploying with a non-root user the command also requires `--user` and
-`--pk` options pointing to the user's SSH key.
+`--pk` options pointing to the user's SSH key. The host running Sealos must have
+`newuidmap` and `newgidmap` installed (typically provided by the `uidmap`
+package) to enable user namespaces.
 
 After the cluster is running the role installs the NVIDIA device plugin and runs a test pod to ensure `nvidia-smi` works inside the cluster.
 

--- a/docs/gpu-k8s-role.md
+++ b/docs/gpu-k8s-role.md
@@ -30,14 +30,17 @@ sealos run \
   --env '{}' \
   --cmd "kubeadm init --skip-phases=addon/kube-proxy"
 ```
-If deploying with a non-root user the command also requires `--user` and
-`--pk` options pointing to the user's SSH key.
+By default the role runs the command as root. Set `root_mode` to `false` to
+deploy in rootless mode, which adds `--user` and `--pk` options pointing to the
+SSH key for `ssh_user`. In rootless mode the host running Sealos must have
+`newuidmap` and `newgidmap` installed (typically provided by the `uidmap`
+package) along with the `fuse-overlayfs` binary to enable user namespaces.
 
 After the cluster is running the role installs the NVIDIA device plugin and runs a test pod to ensure `nvidia-smi` works inside the cluster.
 
 ## Usage
 
-Add the role to your playbook along with the `ssh-trust` role which configures passwordless access from the ops host to the cluster nodes:
+Add the role to your playbook along with the `ssh-trust` role which configures passwordless access from the ops host to the cluster nodes. The `gpu-k8s` role automatically pulls in the `common` role so you do not need to list it separately:
 
 ```yaml
 - hosts: all
@@ -63,6 +66,9 @@ specify the private key path via `ssh_private_key`:
 
 The specified user must be able to log in without a password and have sudo
 access on the target hosts.
+
+Set `root_mode` to `false` if you want the playbook to operate as this user
+instead of root, enabling rootless deployment of the cluster.
 
 
 Example playbook snippet defining the IP lists:

--- a/playbooks/demo_gpu_k8s.yml
+++ b/playbooks/demo_gpu_k8s.yml
@@ -12,4 +12,3 @@
   roles:
     - roles/vhosts/ssh-trust/
     - roles/vhosts/gpu-k8s/
-    - roles/vhosts/common/

--- a/playbooks/roles/vhosts/common/files/install-packages.sh
+++ b/playbooks/roles/vhosts/common/files/install-packages.sh
@@ -4,4 +4,4 @@ export DEBIAN_FRONTEND=noninteractive
 curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg
 sudo echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
 sudo apt-get update
-sudo apt-get install -y vault auditd
+sudo apt-get install -y vault auditd uidmap fuse-overlayfs

--- a/playbooks/roles/vhosts/common/files/install-packages.sh
+++ b/playbooks/roles/vhosts/common/files/install-packages.sh
@@ -4,4 +4,4 @@ export DEBIAN_FRONTEND=noninteractive
 curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg
 sudo echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
 sudo apt-get update
-sudo apt-get install -y vault auditd
+sudo apt-get install -y vault auditd uidmap

--- a/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/defaults/main.yml
@@ -11,3 +11,4 @@ sealos_cmd_env: '{}'
 kubeadm_init_cmd: "kubeadm init --skip-phases=addon/kube-proxy"
 ssh_user: "{{ ansible_user | default('root') }}"
 ssh_private_key: "{{ ansible_ssh_private_key_file | default('~/.ssh/id_rsa') }}"
+root_mode: true

--- a/playbooks/roles/vhosts/gpu-k8s/meta/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common

--- a/playbooks/roles/vhosts/gpu-k8s/meta/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/meta/main.yml
@@ -1,2 +1,2 @@
 dependencies:
-  - role: common
+  - role: vhosts/common

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -79,7 +79,7 @@
   shell: >-
     ssh -o BatchMode=yes -o StrictHostKeyChecking=no \
     -i {{ ssh_private_key }} \
-    {{ ssh_user | default(ansible_ssh_user | default(ansible_user, true) | default('root')) }}@{{ item }} hostname
+    {{ (root_mode | ternary('root', ssh_user | default(ansible_ssh_user | default(ansible_user, true) | default('root')))) }}@{{ item }} hostname
   loop: "{{ master_ips + node_ips }}"
   delegate_to: "{{ ops_host | default(masters | default(master_ips) | first) }}"
   become: false
@@ -95,8 +95,10 @@
       {{ labring_registry.stdout }}/helm:{{ helm_version }} \
       --masters {{ master_ips | join(',') }} \
       --nodes {{ node_ips | join(',') }} \
+{% if not root_mode %}
       --user {{ ssh_user }} \
       --pk {{ ssh_private_key }} \
+{% endif %}
       --env '{{ sealos_cmd_env }}' \
       --cmd "{{ kubeadm_init_cmd }}"
   args:

--- a/playbooks/roles/vhosts/ssh-trust/defaults/main.yml
+++ b/playbooks/roles/vhosts/ssh-trust/defaults/main.yml
@@ -1,2 +1,3 @@
 # Default user for generating and installing SSH key
 ssh_user: "{{ ansible_user | default('root') }}"
+root_mode: true

--- a/playbooks/roles/vhosts/ssh-trust/tasks/main.yml
+++ b/playbooks/roles/vhosts/ssh-trust/tasks/main.yml
@@ -6,7 +6,7 @@
   delegate_to: "{{ ops_host }}"
   run_once: true
   become: true
-  become_user: "{{ ssh_user }}"
+  become_user: "{{ root_mode | ternary('root', ssh_user) }}"
 
 - name: Fetch ops host public key
   slurp:
@@ -15,9 +15,9 @@
   delegate_to: "{{ ops_host }}"
   run_once: true
   become: true
-  become_user: "{{ ssh_user }}"
+  become_user: "{{ root_mode | ternary('root', ssh_user) }}"
 
 - name: Authorize ops host key on cluster hosts
   ansible.builtin.authorized_key:
-    user: "{{ ssh_user }}"
+    user: "{{ root_mode | ternary('root', ssh_user) }}"
     key: "{{ ops_pub_key.content | b64decode }}"


### PR DESCRIPTION
## Summary
- allow gpu-k8s and ssh-trust roles to run in root or rootless mode
- explain rootless mode in the GPU role documentation

## Testing
- `bash -n playbooks/roles/vhosts/common/files/install-packages.sh`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cb3840e00833298e4d8e2b3e3c8d7