### PR TITLE
Add fuse-overlayfs install note

### DIFF
--- a/playbooks/roles/vhosts/common/README.md
+++ b/playbooks/roles/vhosts/common/README.md
@@ -1,0 +1,15 @@
+# Common Role
+
+此目录下的 `common` 角色提供主机初始化配置脚本和模板。
+
+## Ubuntu 20.04+（推荐）
+
+在部分精简安装的系统中，`fuse-overlayfs` 包位于 `universe` 软件源。如果在执行 `install-packages.sh` 脚本时提示无法找到该包，可按照以下步骤手动启用该仓库并安装：
+
+```bash
+sudo add-apt-repository universe
+sudo apt update
+sudo apt install -y fuse-overlayfs
+```
+
+启用 `universe` 仓库后，再次运行角色即可完成所需依赖的安装。


### PR DESCRIPTION
## Summary
- add README for the `common` role detailing how to enable the Ubuntu `universe` repo and install `fuse-overlayfs`

## Testing
- `ansible-lint playbooks/roles/vhosts/common` *(fails: vault password file not found, var-naming, fqcn, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685cd64e7a908332b3d12faf80a66ffa