### PR TITLE
Fix registry path concatenation

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -90,9 +90,9 @@
 - name: Run sealos to create Kubernetes cluster
   shell: |
     sudo sealos run \
-      {{ labring_registry.stdout }}/kubernetes:{{ kubernetes_version }} \
-      {{ labring_registry.stdout }}/cilium:{{ cilium_version }} \
-      {{ labring_registry.stdout }}/helm:{{ helm_version }} \
+      {{ labring_registry.stdout | trim }}/kubernetes:{{ kubernetes_version }} \
+      {{ labring_registry.stdout | trim }}/cilium:{{ cilium_version }} \
+      {{ labring_registry.stdout | trim }}/helm:{{ helm_version }} \
       --masters {{ master_ips | join(',') }} \
       --nodes {{ node_ips | join(',') }} \
       --user {{ ssh_user }} \


### PR DESCRIPTION
## Summary
- trim registry prefix when constructing sealos image URLs

## Testing
- `ansible-lint playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml` *(fails: 23 failures)*

------
https://chatgpt.com/codex/tasks/task_e_685cdd7280c08332a2d22683df7c5ed7