### PR TITLE
Add GPU k8s reset role and use script for sealos

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s-reset/files/reset-gpu-k8s.sh
+++ b/playbooks/roles/vhosts/gpu-k8s-reset/files/reset-gpu-k8s.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if command -v sealos >/dev/null 2>&1; then
+  sudo sealos reset --force || true
+fi
+
+sudo kubeadm reset -f || true
+sudo rm -rf ~/.kube /etc/kubernetes /var/lib/etcd /var/lib/kubelet
+sudo rm -rf /var/lib/cni /etc/cni/net.d
+
+ip link delete cni0 2>/dev/null || true
+ip link delete flannel.1 2>/dev/null || true
+ip link delete docker0 2>/dev/null || true
+ip link delete kube-ipvs0 2>/dev/null || true
+
+iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore || true

--- a/playbooks/roles/vhosts/gpu-k8s-reset/tasks/main.yml
+++ b/playbooks/roles/vhosts/gpu-k8s-reset/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Reset GPU Kubernetes cluster
+  script: files/reset-gpu-k8s.sh
+  when: cluster_reset | default('enable') == 'enable'

--- a/playbooks/roles/vhosts/gpu-k8s/files/run_sealos.sh
+++ b/playbooks/roles/vhosts/gpu-k8s/files/run_sealos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+REGISTRY="$1"
+K8S_VERSION="$2"
+CILIUM_VERSION="$3"
+HELM_VERSION="$4"
+MASTERS="$5"
+NODES="$6"
+SSH_USER="$7"
+ANS_USER="$8"
+CMD_ENV=$(echo "$9" | base64 -d)
+KUBEADM_CMD=$(echo "${10}" | base64 -d)
+
+sudo sealos run \
+  ${REGISTRY}/kubernetes:${K8S_VERSION} \
+  ${REGISTRY}/cilium:${CILIUM_VERSION} \
+  ${REGISTRY}/helm:${HELM_VERSION} \
+  --masters ${MASTERS} \
+  --nodes ${NODES} \
+  --user ${SSH_USER} \
+  --pk /home/${ANS_USER}/.ssh/id_rsa \
+  --env "${CMD_ENV}" \
+  --cmd "${KUBEADM_CMD}"

--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -88,17 +88,17 @@
   run_once: true
 
 - name: Run sealos to create Kubernetes cluster
-  shell: |
-    sudo sealos run \
-      {{ labring_registry.stdout | trim }}/kubernetes:{{ kubernetes_version }} \
-      {{ labring_registry.stdout | trim }}/cilium:{{ cilium_version }} \
-      {{ labring_registry.stdout | trim }}/helm:{{ helm_version }} \
-      --masters {{ master_ips | join(',') }} \
-      --nodes {{ node_ips | join(',') }} \
-      --user {{ ssh_user }} \
-      --pk /home/{{ ansible_user }}/.ssh/id_rsa \
-      --env '{{ sealos_cmd_env }}' \
-      --cmd "{{ kubeadm_init_cmd }}"
+  script: files/run_sealos.sh \
+    {{ labring_registry.stdout | trim }} \
+    {{ kubernetes_version }} \
+    {{ cilium_version }} \
+    {{ helm_version }} \
+    "{{ master_ips | join(',') }}" \
+    "{{ node_ips | join(',') }}" \
+    {{ ssh_user }} \
+    {{ ansible_user }} \
+    "{{ sealos_cmd_env | b64encode }}" \
+    "{{ kubeadm_init_cmd | b64encode }}"
   args:
     executable: /bin/bash
   become: true


### PR DESCRIPTION
## Summary
- run `sealos run` using a script in gpu-k8s role
- add `gpu-k8s-reset` role for cluster cleanup

## Testing
- `bash -n playbooks/roles/vhosts/gpu-k8s/files/run_sealos.sh`
- `bash -n playbooks/roles/vhosts/gpu-k8s-reset/files/reset-gpu-k8s.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d028c2c408332b1869e2b50c59faa