### PR TITLE
Fix sealos_version fact when no GitHub response

### DIFF
--- a/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
+++ b/playbooks/roles/vhosts/gpu-k8s/tasks/install_cluster.yml
@@ -7,8 +7,11 @@
 
 - name: Set sealos_version fact to latest release
   set_fact:
-    sealos_version: "{{ (sealos_latest.content | from_json).tag_name }}"
-  when: sealos_version is not defined or sealos_version == 'latest'
+    sealos_version: "{{ sealos_latest.json.tag_name }}"
+  when:
+    - sealos_version is not defined or sealos_version == 'latest'
+    - sealos_latest is defined
+    - sealos_latest.json is defined
 
 - name: Resolve master and node IPs from hostnames when needed
   set_fact:


### PR DESCRIPTION
## Summary
- avoid undefined variable when fetching latest `sealos` release

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1c83f74c83329f4f0cbda6cee106