### PR TITLE
Add nginx vhost role

### DIFF
--- a/playbooks/roles/vhosts/nginx/defaults/main.yml
+++ b/playbooks/roles/vhosts/nginx/defaults/main.yml
@@ -1,0 +1,6 @@
+vhosts_nginx_cn_homepage_domain: cn-homepage.svc.plus
+vhosts_nginx_artifact_domain: artifact.svc.plus
+vhosts_nginx_ssl_certificate: /etc/ssl/svc.plus.pem
+vhosts_nginx_ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+vhosts_nginx_cn_homepage_root: /var/www/XControl/ui/homepage/out
+vhosts_nginx_artifact_root: /data/update-server

--- a/playbooks/roles/vhosts/nginx/handlers/main.yml
+++ b/playbooks/roles/vhosts/nginx/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload nginx
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded

--- a/playbooks/roles/vhosts/nginx/tasks/main.yml
+++ b/playbooks/roles/vhosts/nginx/tasks/main.yml
@@ -1,0 +1,56 @@
+- name: Install nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+    update_cache: true
+  when:
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_version'] is version('22.04', '>=')
+
+- name: Deploy cn-homepage redirect configuration
+  ansible.builtin.template:
+    src: cn-homepage-redirect.conf.j2
+    dest: /etc/nginx/sites-available/cn-homepage-redirect.conf
+    mode: '0644'
+  notify: Reload nginx
+
+- name: Enable cn-homepage redirect site
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/cn-homepage-redirect.conf
+    dest: /etc/nginx/sites-enabled/cn-homepage-redirect.conf
+    state: link
+  notify: Reload nginx
+
+- name: Deploy cn-homepage site configuration
+  ansible.builtin.template:
+    src: cn-homepage-https.conf.j2
+    dest: /etc/nginx/sites-available/cn-homepage-https.conf
+    mode: '0644'
+  notify: Reload nginx
+
+- name: Enable cn-homepage site
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/cn-homepage-https.conf
+    dest: /etc/nginx/sites-enabled/cn-homepage-https.conf
+    state: link
+  notify: Reload nginx
+
+- name: Deploy artifact site configuration
+  ansible.builtin.template:
+    src: artifact.conf.j2
+    dest: /etc/nginx/sites-available/artifact.conf
+    mode: '0644'
+  notify: Reload nginx
+
+- name: Enable artifact site
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/artifact.conf
+    dest: /etc/nginx/sites-enabled/artifact.conf
+    state: link
+  notify: Reload nginx
+
+- name: Ensure nginx is running
+  ansible.builtin.service:
+    name: nginx
+    state: started
+    enabled: true

--- a/playbooks/roles/vhosts/nginx/templates/artifact.conf.j2
+++ b/playbooks/roles/vhosts/nginx/templates/artifact.conf.j2
@@ -1,0 +1,33 @@
+server {
+  listen 443 ssl http2;
+  server_name {{ vhosts_nginx_artifact_domain }};
+
+  ssl_certificate {{ vhosts_nginx_ssl_certificate }};
+  ssl_certificate_key {{ vhosts_nginx_ssl_certificate_key }};
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+
+  root {{ vhosts_nginx_artifact_root }};
+  index index.html;
+
+  autoindex on;
+  autoindex_exact_size off;
+  autoindex_localtime on;
+
+  location / {
+    add_header Accept-Ranges bytes;
+    try_files $uri $uri/ =404;
+  }
+
+  location ~* \.(dmg|zip|tar\.gz|deb|rpm|exe|pkg|AppImage|apk|ipa)$ {
+    expires 7d;
+    access_log off;
+    add_header Cache-Control "public";
+    add_header Accept-Ranges bytes;
+    try_files $uri =404;
+  }
+
+  location ~ /\. {
+    deny all;
+  }
+}

--- a/playbooks/roles/vhosts/nginx/templates/cn-homepage-https.conf.j2
+++ b/playbooks/roles/vhosts/nginx/templates/cn-homepage-https.conf.j2
@@ -1,0 +1,35 @@
+server {
+  listen 443 ssl http2;
+  server_name {{ vhosts_nginx_cn_homepage_domain }};
+
+  ssl_certificate {{ vhosts_nginx_ssl_certificate }};
+  ssl_certificate_key {{ vhosts_nginx_ssl_certificate_key }};
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+
+  root {{ vhosts_nginx_cn_homepage_root }};
+  index index.html;
+
+  location /api/ {
+      proxy_pass http://127.0.0.1:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?)$ {
+    expires 30d;
+    access_log off;
+    add_header Cache-Control "public";
+  }
+
+  location ~ /\. {
+    deny all;
+  }
+}

--- a/playbooks/roles/vhosts/nginx/templates/cn-homepage-redirect.conf.j2
+++ b/playbooks/roles/vhosts/nginx/templates/cn-homepage-redirect.conf.j2
@@ -1,0 +1,5 @@
+server {
+  listen 80;
+  server_name {{ vhosts_nginx_cn_homepage_domain }};
+  return 301 https://{{ vhosts_nginx_cn_homepage_domain }}$request_uri;
+}


### PR DESCRIPTION
## Summary
- add nginx role for static and artifact sites
- configure HTTP redirect and HTTPS vhosts with templating

## Testing
- `ansible-lint playbooks/roles/vhosts/nginx`
- `ansible-playbook -i localhost, -c local /tmp/nginx_test.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68900f8d8a8c8332afe573f13fa2152f