### PR TITLE
chore: use official OpenResty repository

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -1,12 +1,22 @@
 - name: Install prerequisites for OpenResty
   apt:
-    name: software-properties-common
+    name:
+      - curl
+      - gnupg
+      - apt-transport-https
     state: present
     update_cache: yes
 
+- name: Import OpenResty GPG key
+  command: >-
+    bash -c 'curl -fsSL https://openresty.org/package/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/openresty.gpg'
+  args:
+    creates: /usr/share/keyrings/openresty.gpg
+
 - name: Add OpenResty apt repository
   apt_repository:
-    repo: ppa:openresty/ppa
+    repo: "deb [signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu jammy main"
+    filename: openresty
     state: present
 
 - name: Install OpenResty


### PR DESCRIPTION
## Summary
- use OpenResty official deb repo instead of PPA

## Testing
- `ANSIBLE_ROLES_PATH=/workspace/gitops/playbooks/roles/vhosts ansible-playbook --syntax-check /tmp/test_openresty.yml`


------
https://chatgpt.com/codex/tasks/task_e_6890b98727008332ae69c8680190e2c2