### PR TITLE
feat: verify OpenResty core API

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -36,3 +36,13 @@
     name: openresty
     enabled: yes
     state: started
+
+- name: Verify OpenResty core API
+  shell: |
+    curl -fsS -X POST http://127.0.0.1:8080/api/askai \
+      -H "Content-Type: application/json" \
+      -d '{"question":"你好"}'
+  register: openresty_verify
+  retries: 5
+  delay: 3
+  until: openresty_verify.rc == 0


### PR DESCRIPTION
## Summary
- verify OpenResty core API after deployment

## Testing
- `ansible-lint playbooks/roles/vhosts/OpenResty/tasks/main.yml` (fails: fqcn[action-core], yaml[truthy], risky-file-permissions, command-instead-of-module, no-changed-when)
- `yamllint playbooks/roles/vhosts/OpenResty/tasks/main.yml` (fails: missing document start, truthy value, line length)


------
https://chatgpt.com/codex/tasks/task_e_6891893be8dc833280d152691c96199a