### PR TITLE
feat: add nginx proxy role

### DIFF
--- a/playbooks/roles/vhosts/nginx-proxy/defaults/main.yml
+++ b/playbooks/roles/vhosts/nginx-proxy/defaults/main.yml
@@ -1,0 +1,4 @@
+vhosts_nginx_proxy_domain: global-homepage.svc.plus
+vhosts_nginx_proxy_upstream_host: global-homepage.onwalk.net
+vhosts_nginx_proxy_ssl_certificate: /etc/ssl/svc.plus.pem
+vhosts_nginx_proxy_ssl_certificate_key: /etc/ssl/svc.plus.rsa.key

--- a/playbooks/roles/vhosts/nginx-proxy/handlers/main.yml
+++ b/playbooks/roles/vhosts/nginx-proxy/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload nginx
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded

--- a/playbooks/roles/vhosts/nginx-proxy/tasks/main.yml
+++ b/playbooks/roles/vhosts/nginx-proxy/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Install nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+    update_cache: true
+  when:
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_version'] is version('22.04', '>=')
+
+- name: Deploy nginx proxy configuration
+  ansible.builtin.template:
+    src: nginx-proxy.conf.j2
+    dest: /etc/nginx/sites-available/nginx-proxy.conf
+    mode: '0644'
+  notify: Reload nginx
+
+- name: Enable nginx proxy site
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/nginx-proxy.conf
+    dest: /etc/nginx/sites-enabled/nginx-proxy.conf
+    state: link
+  notify: Reload nginx
+
+- name: Ensure nginx is running
+  ansible.builtin.service:
+    name: nginx
+    state: started
+    enabled: true

--- a/playbooks/roles/vhosts/nginx-proxy/templates/nginx-proxy.conf.j2
+++ b/playbooks/roles/vhosts/nginx-proxy/templates/nginx-proxy.conf.j2
@@ -1,0 +1,45 @@
+# HTTP redirect to HTTPS
+server {
+  listen 80;
+  server_name {{ vhosts_nginx_proxy_domain }};
+  return 301 https://{{ vhosts_nginx_proxy_domain }}$request_uri;
+}
+
+# HTTPS entrypoint
+server {
+  listen 443 ssl http2;
+  server_name {{ vhosts_nginx_proxy_domain }};
+
+  ssl_certificate     {{ vhosts_nginx_proxy_ssl_certificate }};
+  ssl_certificate_key {{ vhosts_nginx_proxy_ssl_certificate_key }};
+
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+
+  location / {
+    proxy_pass https://{{ vhosts_nginx_proxy_upstream_host }};
+
+    # Enable TLS SNI
+    proxy_ssl_server_name on;
+
+    # Spoof browser headers to avoid Cloudflare challenge
+    proxy_set_header Host {{ vhosts_nginx_proxy_upstream_host }};
+    proxy_set_header User-Agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36";
+    proxy_set_header Accept "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+    proxy_set_header Referer "https://{{ vhosts_nginx_proxy_upstream_host }}/";
+
+    # Preserve client IP
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # HTTP/1.1 and clear connection upgrade headers
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    # Optional timeout controls
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 30s;
+    proxy_read_timeout 30s;
+  }
+}


### PR DESCRIPTION
## Summary
- rename global homepage proxy to generic nginx proxy role
- allow domain, upstream host, and SSL certs to be set via variables

## Testing
- `ANSIBLE_CONFIG=/tmp/ansible.cfg ansible-playbook --syntax-check /tmp/test_nginx_proxy.yml`


------
https://chatgpt.com/codex/tasks/task_e_6890b8fab6f08332a5a43de268c32344