### PR TITLE
Add entry playbook for OpenResty

### DIFF
--- a/playbooks/openresty.yml
+++ b/playbooks/openresty.yml
@@ -1,0 +1,15 @@
+- hosts: all
+  become: true
+  vars:
+    # Use the inventory hostname for delegation so Ansible
+    # applies the correct connection variables
+    ops_host: "k8s-1"
+    masters:
+      - "k8s-1"
+    nodes:
+      - "k8s-2"
+      - "k8s-3"
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/ssh-trust/
+    - roles/vhosts/OpenResty/


### PR DESCRIPTION
## Summary
- add OpenResty playbook referencing existing vhosts roles

## Testing
- `ansible-playbook --syntax-check playbooks/openresty.yml` *(fails: Invalid vault password was provided from file)*

------
https://chatgpt.com/codex/tasks/task_e_68919273f5d0833298eeba80f7201140