### PR TITLE
feat: configure OpenResty vhosts for multiple domains

### DIFF
--- a/playbooks/openresty.yml
+++ b/playbooks/openresty.yml
@@ -1,15 +1,33 @@
-- hosts: all
+---
+- name: setup OpenResty server
+  hosts: icp-aliyun
   become: true
   vars:
-    # Use the inventory hostname for delegation so Ansible
-    # applies the correct connection variables
-    ops_host: "k8s-1"
-    masters:
-      - "k8s-1"
-    nodes:
-      - "k8s-2"
-      - "k8s-3"
+    domain:
+      - name: cn-homepage.svc.plus
+        ssl_certificate: /etc/ssl/svc.plus.pem
+        ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+      - name: cn-artifact.svc.plus
+        ssl_certificate: /etc/ssl/svc.plus.pem
+        ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
   roles:
     - roles/vhosts/common/
     - roles/vhosts/ssh-trust/
     - roles/vhosts/OpenResty/
+---
+- name: setup OpenResty server
+  hosts: global-hub
+  become: true
+  vars:
+    domain:
+      - name: global-homepage.svc.plus
+        ssl_certificate: /etc/ssl/svc.plus.pem
+        ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+      - name: global-artifact.svc.plus
+        ssl_certificate: /etc/ssl/svc.plus.pem
+        ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/ssh-trust/
+    - roles/vhosts/OpenResty/
+

--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: Verify OpenResty core API
   shell: |
-    curl -fsS -X POST http://127.0.0.1:8080/api/askai \
+    curl -fsS -X POST http://127.0.0.1/api/askai \
       -H "Content-Type: application/json" \
       -d '{"question":"你好"}'
   register: openresty_verify

--- a/playbooks/roles/vhosts/OpenResty/templates/nginx.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/nginx.conf.j2
@@ -4,9 +4,13 @@ events { worker_connections 1024; }
 http {
     lua_shared_dict limit_cache 10m;
 
+{% for site in domain %}
     server {
         listen 80;
-        server_name localhost;
+        listen 443 ssl;
+        server_name {{ site.name }};
+        ssl_certificate {{ site.ssl_certificate }};
+        ssl_certificate_key {{ site.ssl_certificate_key }};
 
         location /api/askai {
             access_by_lua_block {
@@ -53,4 +57,6 @@ http {
             proxy_pass http://127.0.0.1:5000;
         }
     }
+{% endfor %}
 }
+


### PR DESCRIPTION
## Summary
- build new OpenResty playbook targeting icp-aliyun and global-hub with domain-specific SSL settings
- generate OpenResty server blocks per domain and verify core API on localhost

## Testing
- `ansible-playbook playbooks/openresty.yml --syntax-check` *(fails: Invalid vault password was provided from file (/root/.vault_password))*

------
https://chatgpt.com/codex/tasks/task_e_6891caf524848332a99442c56e754b06