### PR TITLE
nginx(conf): fix regex escaping for dot/hidden files

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/templates/site.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/site.conf.j2
@@ -30,7 +30,7 @@ server {
     try_files $uri =404;
   }
 
-  location ~ /\\. {
+  location ~ /\. {
     deny all;
   }
 }
@@ -110,14 +110,14 @@ server {
   }
 
   # 静态资源缓存
-  location ~* \\.(?:ico|css|js|gif|jpe?g|png|woff2?)$ {
+  location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?)$ {
     expires 30d;
     access_log off;
     add_header Cache-Control "public";
   }
 
   # 隐藏 . 文件
-  location ~ /\\. {
+  location ~ /\. {
     deny all;
   }
 }


### PR DESCRIPTION
## Summary
- fix OpenResty template regex escaping so static assets and dotfiles match correctly

## Testing
- `ansible-lint playbooks/roles/vhosts/OpenResty` *(fails: vault password file not found, 19 rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a1a11a688332a540ca733b150ab5