### PR TITLE
Add roles for node and process exporters

### DIFF
--- a/playbooks/deploy_exporters_vhosts.yml
+++ b/playbooks/deploy_exporters_vhosts.yml
@@ -1,0 +1,18 @@
+- name: setup Prometheus exporters
+  hosts: cn-homepage.svc.plus
+  become: true
+  vars:
+    group: cn-homepage.svc.plus
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/node_exporter/
+    - roles/vhosts/process_exporter/
+- name: setup Prometheus exporters
+  hosts: global-homepage.svc.plus
+  become: true
+  vars:
+    group: global-homepage.svc.plus
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/node_exporter/
+    - roles/vhosts/process_exporter/

--- a/playbooks/roles/vhosts/node_exporter/meta/main.yml
+++ b/playbooks/roles/vhosts/node_exporter/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common

--- a/playbooks/roles/vhosts/node_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/node_exporter/tasks/main.yml
@@ -1,0 +1,62 @@
+- name: Ensure node_exporter user exists
+  ansible.builtin.user:
+    name: node_exporter
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+  when: inventory_hostname in groups[group]
+
+- name: Download node_exporter archive
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/prometheus/node_exporter/releases/download/v{{
+      node_exporter_version | default('1.8.2') }}/node_exporter-{{
+      node_exporter_version | default('1.8.2') }}.linux-amd64.tar.gz
+    dest: /tmp/node_exporter.tar.gz
+    mode: "0644"
+  when: inventory_hostname in groups[group]
+
+- name: Extract node_exporter
+  ansible.builtin.unarchive:
+    src: /tmp/node_exporter.tar.gz
+    dest: /tmp
+    remote_src: true
+    creates: "/tmp/node_exporter-{{ node_exporter_version | default('1.8.2') }}.linux-amd64"
+  when: inventory_hostname in groups[group]
+
+- name: Install node_exporter binary
+  ansible.builtin.copy:
+    src: "/tmp/node_exporter-{{ node_exporter_version | default('1.8.2') }}.linux-amd64/node_exporter"
+    dest: /usr/local/bin/node_exporter
+    mode: '0755'
+    remote_src: true
+  when: inventory_hostname in groups[group]
+
+- name: Remove node_exporter archive
+  ansible.builtin.file:
+    path: /tmp/node_exporter.tar.gz
+    state: absent
+  when: inventory_hostname in groups[group]
+
+- name: Cleanup extracted directory
+  ansible.builtin.file:
+    path: "/tmp/node_exporter-{{ node_exporter_version | default('1.8.2') }}.linux-amd64"
+    state: absent
+  when: inventory_hostname in groups[group]
+
+- name: Create node_exporter service
+  ansible.builtin.template:
+    src: node_exporter.service
+    dest: /etc/systemd/system/node_exporter.service
+    owner: root
+    group: root
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Enable and start node_exporter
+  ansible.builtin.systemd:
+    name: node_exporter
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: inventory_hostname in groups[group]

--- a/playbooks/roles/vhosts/node_exporter/templates/node_exporter.service
+++ b/playbooks/roles/vhosts/node_exporter/templates/node_exporter.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Prometheus Node Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+ExecStart=/usr/local/bin/node_exporter --web.listen-address={{ node_exporter_bind_addr | default('0.0.0.0') }}:{{ node_exporter_port | default('9100') }} --collector.tcpstat --collector.processes
+Restart=always
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/vhosts/process_exporter/meta/main.yml
+++ b/playbooks/roles/vhosts/process_exporter/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common

--- a/playbooks/roles/vhosts/process_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/process_exporter/tasks/main.yml
@@ -1,0 +1,71 @@
+- name: Ensure process_exporter user exists
+  ansible.builtin.user:
+    name: process_exporter
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+  when: inventory_hostname in groups[group]
+
+- name: Download process-exporter archive
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/ncabatoff/process-exporter/releases/download/v{{
+      process_exporter_version | default('0.7.10') }}/process-exporter-{{
+      process_exporter_version | default('0.7.10') }}.linux-amd64.tar.gz
+    dest: /tmp/process-exporter.tar.gz
+    mode: "0644"
+  when: inventory_hostname in groups[group]
+
+- name: Extract process-exporter
+  ansible.builtin.unarchive:
+    src: /tmp/process-exporter.tar.gz
+    dest: /tmp
+    remote_src: true
+    creates: "/tmp/process-exporter-{{ process_exporter_version | default('0.7.10') }}.linux-amd64"
+  when: inventory_hostname in groups[group]
+
+- name: Install process-exporter binary
+  ansible.builtin.copy:
+    src: "/tmp/process-exporter-{{ process_exporter_version | default('0.7.10') }}.linux-amd64/process-exporter"
+    dest: /usr/local/bin/process-exporter
+    mode: '0755'
+    remote_src: true
+  when: inventory_hostname in groups[group]
+
+- name: Remove process-exporter archive
+  ansible.builtin.file:
+    path: /tmp/process-exporter.tar.gz
+    state: absent
+  when: inventory_hostname in groups[group]
+
+- name: Cleanup extracted process-exporter directory
+  ansible.builtin.file:
+    path: "/tmp/process-exporter-{{ process_exporter_version | default('0.7.10') }}.linux-amd64"
+    state: absent
+  when: inventory_hostname in groups[group]
+
+- name: Deploy process-exporter config
+  ansible.builtin.template:
+    src: process-exporter.yml
+    dest: /etc/process-exporter.yml
+    owner: process_exporter
+    group: process_exporter
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Create process-exporter service
+  ansible.builtin.template:
+    src: process-exporter.service
+    dest: /etc/systemd/system/process-exporter.service
+    owner: root
+    group: root
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Enable and start process-exporter
+  ansible.builtin.systemd:
+    name: process-exporter
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: inventory_hostname in groups[group]

--- a/playbooks/roles/vhosts/process_exporter/templates/process-exporter.service
+++ b/playbooks/roles/vhosts/process_exporter/templates/process-exporter.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=process-exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=process_exporter
+Group=process_exporter
+ExecStart=/usr/local/bin/process-exporter --config.path /etc/process-exporter.yml --web.listen-address={{ process_exporter_bind_addr | default('0.0.0.0') }}:{{ process_exporter_port | default('9256') }}
+Restart=always
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/vhosts/process_exporter/templates/process-exporter.yml
+++ b/playbooks/roles/vhosts/process_exporter/templates/process-exporter.yml
@@ -1,0 +1,5 @@
+{% raw %}
+process_names:
+  - name: "{{.Comm}}"
+    cmdline: [".+"]
+{% endraw %}


### PR DESCRIPTION
## Summary
- add node_exporter ansible role to install and run Prometheus node exporter
- add process_exporter ansible role with basic config and systemd service
- add playbook to deploy both exporters on homepage hosts

## Testing
- `ansible-lint playbooks/roles/vhosts/node_exporter playbooks/roles/vhosts/process_exporter`
- `ansible-lint playbooks/deploy_exporters_vhosts.yml` *(fails: style issues in existing roles/vhosts/common)*

------
https://chatgpt.com/codex/tasks/task_e_68a29b00a0e083328af732fe5b9f3e10