### PR TITLE
feat: use V2Fly GeoIP data for OpenResty

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -46,18 +46,11 @@
     mode: "0755"
 
 # yamllint disable rule:line-length
-- name: Download GeoLite2 Country database
+- name: Download V2Fly GeoIP database
   get_url:
-    url: https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz
-    dest: /usr/share/GeoIP/GeoLite2-Country.mmdb.gz
+    url: https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+    dest: /usr/share/GeoIP/geoip.dat
 # yamllint enable rule:line-length
-
-- name: Decompress GeoLite2 Country database
-  unarchive:
-    src: /usr/share/GeoIP/GeoLite2-Country.mmdb.gz
-    dest: /usr/share/GeoIP/
-    remote_src: true
-    creates: /usr/share/GeoIP/GeoLite2-Country.mmdb
 
 - name: Ensure sites-available directory exists
   file:

--- a/playbooks/roles/vhosts/OpenResty/templates/geo_redirect.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/geo_redirect.conf.j2
@@ -17,7 +17,7 @@ server {
       end
 
       local geoip = require("resty.maxminddb")
-      local reader, err = geoip.new("/usr/share/GeoIP/GeoLite2-Country.mmdb")
+      local reader, err = geoip.new("/usr/share/GeoIP/geoip.dat")
       if not reader then
         ngx.log(ngx.ERR, "failed to open MaxMind DB: ", err)
         ngx.header["Set-Cookie"] = "region=GLOBAL; Path=/; Max-Age=3600"


### PR DESCRIPTION
## Summary
- fetch V2Fly geoip.dat in OpenResty role
- use the new geoip.dat in geo redirect template

## Testing
- `yamllint playbooks/roles/vhosts/OpenResty/tasks/main.yml` *(fails: missing document start "---")*

------
https://chatgpt.com/codex/tasks/task_e_68a2daf3bca08332b10dad19b8a658be