### PR TITLE
feat: disable GeoIP setup for OpenResty role

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/tasks/geoip.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/geoip.yml
@@ -1,0 +1,23 @@
+- name: Install GeoIP dependencies
+  apt:
+    name: luarocks
+    state: present
+    update_cache: true
+
+- name: Install lua-resty-maxminddb
+  command: "luarocks install lua-resty-maxminddb"
+  args:
+    creates: /usr/local/openresty/site/lualib/resty/maxminddb.lua
+
+- name: Ensure GeoIP database directory exists
+  file:
+    path: /usr/share/GeoIP
+    state: directory
+    mode: "0755"
+
+# yamllint disable rule:line-length
+- name: Download V2Fly GeoIP database
+  get_url:
+    url: https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+    dest: /usr/share/GeoIP/geoip.dat
+# yamllint enable rule:line-length

--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -28,30 +28,6 @@
     state: present
     update_cache: true
 
-- name: Install GeoIP dependencies
-  apt:
-    name: luarocks
-    state: present
-    update_cache: true
-
-- name: Install lua-resty-maxminddb
-  command: "luarocks install lua-resty-maxminddb"
-  args:
-    creates: /usr/local/openresty/site/lualib/resty/maxminddb.lua
-
-- name: Ensure GeoIP database directory exists
-  file:
-    path: /usr/share/GeoIP
-    state: directory
-    mode: "0755"
-
-# yamllint disable rule:line-length
-- name: Download V2Fly GeoIP database
-  get_url:
-    url: https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
-    dest: /usr/share/GeoIP/geoip.dat
-# yamllint enable rule:line-length
-
 - name: Ensure sites-available directory exists
   file:
     path: /usr/local/openresty/nginx/conf/sites-available


### PR DESCRIPTION
## Summary
- disable GeoIP steps in OpenResty role by moving them to a separate subtask file

## Testing
- `ansible-playbook --syntax-check playbooks/deploy_openresty_vhosts.yml` *(fails: The vault password file /root/.vault_password was not found)*
- `ansible-lint playbooks/roles/vhosts/OpenResty/tasks/main.yml playbooks/roles/vhosts/OpenResty/tasks/geoip.yml` *(fails: 21 rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4057265788332a2bb0804daea7040