### PR TITLE
feat: add vhost defaults and autoindex

### DIFF
--- a/playbooks/deploy_openresty_vhosts.yml
+++ b/playbooks/deploy_openresty_vhosts.yml
@@ -38,6 +38,9 @@
           - global-artifact.svc.plus
         ssl_certificate: /etc/ssl/svc.plus.pem
         ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+        root: /data/update-server
+        autoindex_paths:
+          - "/"
         type: artifact
   roles:
     - roles/vhosts/common/

--- a/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
@@ -7,13 +7,30 @@ server {
   ssl_protocols       TLSv1.2 TLSv1.3;
   ssl_ciphers         HIGH:!aNULL:!MD5;
 
-  root /data/update-server;
+  root {{ item.root | default(vhost_defaults.root) }};
   index index.html;
 
+  {% set autoindex_paths = item.autoindex_paths | default(vhost_defaults.autoindex_paths) %}
+
   location / {
+    {% if '/' in autoindex_paths %}
+    autoindex on;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+    {% endif %}
     add_header Accept-Ranges bytes;
     try_files $uri $uri/ =404;
   }
+
+  {% for path in autoindex_paths %}
+  {% if path != '/' %}
+  location {{ path }} {
+    autoindex on;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+  }
+  {% endif %}
+  {% endfor %}
 
   location ~* \.(dmg|zip|tar\.gz|deb|rpm|exe|pkg|AppImage|apk|ipa)$ {
     expires 7d;

--- a/playbooks/roles/vhosts/common/defaults/main.yml
+++ b/playbooks/roles/vhosts/common/defaults/main.yml
@@ -36,3 +36,8 @@ journald_log_rotation:          # 启用 journald 日志管理
     #    selinux_enable: false
     #    ssh_auth:
     #      key: /root/.ssh/id_rsa.pub
+
+vhosts: []
+vhost_defaults:
+  root: /data/update-server
+  autoindex_paths: []


### PR DESCRIPTION
## Summary
- define default vhost root and autoindex paths
- enable autoindex for global artifact site via variables
- template artifact.conf.j2 to respect root and autoindex lists

## Testing
- `ansible-playbook --syntax-check playbooks/deploy_openresty_vhosts.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a411cfa0148332a3d2f89bae286826