### PR TITLE
feat(openresty): sync artifact vhost config

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
@@ -7,11 +7,15 @@ server {
   ssl_protocols       TLSv1.2 TLSv1.3;
   ssl_ciphers         HIGH:!aNULL:!MD5;
 
-  root {{ item.root | default(vhost_defaults.root) }};
+  root  {{ item.root | default(vhost_defaults.root) }};
   index index.html;
+
+  # 建议：放行 ACME/健康检查等（避免被 dotfile 规则误伤）
+  location ^~ /.well-known/ { allow all; }
 
   {% set autoindex_paths = item.autoindex_paths | default(vhost_defaults.autoindex_paths) %}
 
+  # 目录浏览（打开 autoindex）—可列出整个 {{ item.root | default(vhost_defaults.root) }}
   location / {
     {% if '/' in autoindex_paths %}
     autoindex on;
@@ -19,7 +23,7 @@ server {
     autoindex_localtime on;
     {% endif %}
     add_header Accept-Ranges bytes;
-    try_files $uri $uri/ =404;
+    try_files $uri $uri/ =404;   # 保持原有 404 语义
   }
 
   {% for path in autoindex_paths %}
@@ -32,15 +36,17 @@ server {
   {% endif %}
   {% endfor %}
 
-  location ~* \.(dmg|zip|tar\.gz|deb|rpm|exe|pkg|AppImage|apk|ipa)$ {
+  # 常见安装包直下读文件（大小写不敏感）
+  # 这里无需 try_files，命中即直接读文件；减少一次磁盘判断
+  location ~* \.(?:dmg|zip|tar\.gz|deb|rpm|exe|pkg|appimage|apk|ipa)$ {
     expires 7d;
     access_log off;
     add_header Cache-Control "public";
     add_header Accept-Ranges bytes;
-    try_files $uri =404;
   }
 
-  location ~ /\.[^/]+ {
+  # 隐藏 dotfiles（但不拦 /.well-known/，已在上面放行）
+  location ~ /\.(?!well-known/)[^/]+ {
     deny all;
   }
 }


### PR DESCRIPTION
## Summary
- allow ACME and health checks via `.well-known`
- document autoindex usage and hide dotfiles except `.well-known`
- add archive download pattern and cache headers for installers

## Testing
- `ansible-playbook --syntax-check playbooks/deploy_openresty_vhosts.yml` *(fails: The vault password file /root/.vault_password was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42273782c8332a774339daaa38471