### PR TITLE
feat: ensure artifact vhost root permissions

### DIFF
--- a/playbooks/deploy_openresty_vhosts.yml
+++ b/playbooks/deploy_openresty_vhosts.yml
@@ -16,6 +16,7 @@
           - cn-artifact.svc.plus
         ssl_certificate: /etc/ssl/svc.plus.pem
         ssl_certificate_key: /etc/ssl/svc.plus.rsa.key
+        root: /data/update-server
         type: artifact
   roles:
     - roles/vhosts/common/

--- a/playbooks/roles/vhosts/OpenResty/tasks/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/tasks/main.yml
@@ -47,6 +47,15 @@
   loop: "{{ vhosts | default([]) }}"
   notify: Restart OpenResty
 
+- name: Ensure artifact root directories exist
+  file:
+    path: "{{ item.root }}"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: "0755"
+  loop: "{{ vhosts | default([]) | selectattr('type', 'equalto', 'artifact') | selectattr('root', 'defined') | list }}"
+
 - name: Enable and start OpenResty
   systemd:
     name: openresty

--- a/playbooks/roles/vhosts/OpenResty/templates/nginx.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/nginx.conf.j2
@@ -1,4 +1,5 @@
 worker_processes  auto;
+user www-data;
 
 events {
     worker_connections  1024;


### PR DESCRIPTION
## Summary
- add `/data/update-server` root for `cn-artifact.svc.plus`
- ensure artifact vhost roots exist with `www-data` ownership and `0755` perms

## Testing
- `ANSIBLE_VAULT_PASSWORD_FILE=/dev/null ansible-lint playbooks/roles/vhosts/OpenResty` *(fails: Invalid vault password was provided from file (/dev/null))*

------
https://chatgpt.com/codex/tasks/task_e_68a4450d1cd483328997638afe69ff72