### PR TITLE
feat: add OpenObserve ansible role

### DIFF
--- a/playbooks/roles/vhosts/openobserve/defaults/main.yml
+++ b/playbooks/roles/vhosts/openobserve/defaults/main.yml
@@ -1,0 +1,8 @@
+openobserve_working_dir: /data
+openobserve_binary: /usr/bin/openobserve
+openobserve_root_user_email: root@example.com
+openobserve_root_user_password: changeme
+openobserve_memory_cache_max_size: 256
+openobserve_compact_enabled: false
+openobserve_query_parallelism: 1
+openobserve_feature_per_thread_lock: true

--- a/playbooks/roles/vhosts/openobserve/tasks/main.yml
+++ b/playbooks/roles/vhosts/openobserve/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Ensure OpenObserve working directory exists
+  ansible.builtin.file:
+    path: "{{ openobserve_working_dir }}"
+    state: directory
+    mode: '0755'
+  when: inventory_hostname in groups[group]
+
+- name: Install OpenObserve systemd service
+  ansible.builtin.template:
+    src: openobserve.service.j2
+    dest: /etc/systemd/system/openobserve.service
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Enable and start OpenObserve service
+  ansible.builtin.systemd:
+    name: openobserve
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: inventory_hostname in groups[group]

--- a/playbooks/roles/vhosts/openobserve/templates/openobserve.service.j2
+++ b/playbooks/roles/vhosts/openobserve/templates/openobserve.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=OpenObserve Service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory={{ openobserve_working_dir }}
+ExecStart={{ openobserve_binary }}
+Restart=on-failure
+RestartSec=5
+
+Environment=ZO_ROOT_USER_EMAIL={{ openobserve_root_user_email }}
+Environment=ZO_ROOT_USER_PASSWORD={{ openobserve_root_user_password }}
+Environment=ZO_MEMORY_CACHE_MAX_SIZE={{ openobserve_memory_cache_max_size }}
+Environment=ZO_COMPACT_ENABLED={{ openobserve_compact_enabled | lower }}
+Environment=ZO_QUERY_PARALLELISM={{ openobserve_query_parallelism }}
+Environment=ZO_FEATURE_PER_THREAD_LOCK={{ openobserve_feature_per_thread_lock | lower }}
+
+# Optional: Increase file descriptor limit to avoid errors with many small files
+# LimitNOFILE=262144
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add OpenObserve role with configurable defaults
- template systemd unit to manage OpenObserve service
- ensure working directory and service start

## Testing
- `ansible-lint playbooks/roles/vhosts/openobserve/tasks/main.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b19300e5fc833296685ff406fdd0ce