### PR TITLE
fix: correct otelcol extraction directory

### DIFF
--- a/playbooks/roles/vhosts/otel-collector/tasks/main.yml
+++ b/playbooks/roles/vhosts/otel-collector/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Extract otelcol-contrib
   ansible.builtin.unarchive:
     src: "/tmp/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}.tar.gz"
-    dest: /tmp
+    dest: "/tmp/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}"
     remote_src: true
     creates: "/tmp/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}"
   when: inventory_hostname in groups[group]
@@ -61,7 +61,8 @@
 # === 可选：Debian/Ubuntu .deb 安装方案（默认禁用） ===
 # - name: Download otelcol-contrib deb
 #   ansible.builtin.get_url:
-#     url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{ otel_collector_version }}/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}.deb"
+#     url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/"
+#       "v{{ otel_collector_version }}/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}.deb"
 #     dest: "/tmp/otelcol-contrib_{{ otel_collector_version }}_linux_{{ otel_arch }}.deb"
 #     mode: "0644"
 #   when:


### PR DESCRIPTION
## Summary
- ensure otel-collector unpacks to version-specific directory
- split long commented download URL to satisfy ansible-lint

## Testing
- `ansible-lint playbooks/roles/vhosts/otel-collector/tasks/main.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b80dc2717483329fa882f696f53be1