### PR TITLE
Fix autoindex template logic

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
+++ b/playbooks/roles/vhosts/OpenResty/templates/artifact.conf.j2
@@ -24,15 +24,15 @@ server {
     add_header Accept-Ranges bytes;
     try_files $uri $uri/ =404;   # 保持原有 404 语义
   }
-  {% elif %}
+  {% elif autoindex_paths %}
     {% for path in autoindex_paths %}
   location {{ path }} {
     autoindex on;
     autoindex_exact_size off;
     autoindex_localtime on;
   }
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  {% endif %}
 
   # 常见安装包直下读文件（大小写不敏感）
   # 这里无需 try_files，命中即直接读文件；减少一次磁盘判断


### PR DESCRIPTION
## Summary
- fix invalid Jinja syntax in artifact vhost template
- ensure optional autoindex paths only render when provided

## Testing
- `ansible-playbook -i inventory.ini deploy_openresty_vhosts.yml -D -C` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_68cd50f311188332ac4fcc1e34b24c8c