### PR TITLE
Add OpenResty vhost defaults

### DIFF
--- a/playbooks/roles/vhosts/OpenResty/defaults/main.yml
+++ b/playbooks/roles/vhosts/OpenResty/defaults/main.yml
@@ -1,0 +1,3 @@
+vhost_defaults:
+  root: /data/update-server
+  autoindex_paths: []


### PR DESCRIPTION
## Summary
- define default root and autoindex paths for OpenResty vhosts to avoid undefined variable errors

## Testing
- ansible-playbook playbooks/deploy_openresty_vhosts.yml --syntax-check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd532501d08332a7ba9c74d42504aa