### PR TITLE
Add PostgreSQL vhost role for Ubuntu 22.04+

### DIFF
--- a/playbooks/deploy_postgres_vhosts.yml
+++ b/playbooks/deploy_postgres_vhosts.yml
@@ -1,0 +1,8 @@
+- name: Deploy PostgreSQL on vhosts
+  hosts: "{{ postgresql_target | default('postgresql') }}"
+  become: true
+  vars:
+    group: "{{ group | default(postgresql_target | default('postgresql')) }}"
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/postgres/

--- a/playbooks/roles/vhosts/postgres/defaults/main.yml
+++ b/playbooks/roles/vhosts/postgres/defaults/main.yml
@@ -1,0 +1,23 @@
+postgresql_version: "16"
+postgresql_listen_addresses: "*"
+postgresql_port: 5432
+postgresql_conf_path: "/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf"
+postgresql_hba_path: "/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf"
+postgresql_allowed_hosts: []
+postgresql_auth_method: "scram-sha-256"
+postgresql_password_encryption: "scram-sha-256"
+postgresql_service_name: "postgresql"
+postgresql_package_dependencies:
+  - ca-certificates
+  - gnupg
+  - lsb-release
+postgresql_extra_packages:
+  - python3-psycopg2
+postgresql_packages_base:
+  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-client-{{ postgresql_version }}"
+  - "postgresql-contrib-{{ postgresql_version }}"
+postgresql_use_official_repo: true
+postgresql_repo_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+postgresql_repo_key_path: "/usr/share/keyrings/postgresql-archive-keyring.gpg"
+postgresql_repo: "deb [signed-by={{ postgresql_repo_key_path }}] https://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"

--- a/playbooks/roles/vhosts/postgres/handlers/main.yml
+++ b/playbooks/roles/vhosts/postgres/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart PostgreSQL
+  ansible.builtin.systemd:
+    name: "{{ postgresql_service_name }}"
+    state: restarted
+    daemon_reload: true

--- a/playbooks/roles/vhosts/postgres/meta/main.yml
+++ b/playbooks/roles/vhosts/postgres/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common

--- a/playbooks/roles/vhosts/postgres/tasks/main.yml
+++ b/playbooks/roles/vhosts/postgres/tasks/main.yml
@@ -1,0 +1,120 @@
+- name: Ensure PostgreSQL repository prerequisites are installed
+  ansible.builtin.apt:
+    name: "{{ postgresql_package_dependencies | list }}"
+    state: present
+    update_cache: true
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version is version('22.04', '>=')
+    - postgresql_use_official_repo | bool
+
+- name: Download PostgreSQL repository signing key
+  ansible.builtin.get_url:
+    url: "{{ postgresql_repo_key_url }}"
+    dest: "{{ postgresql_repo_key_path }}"
+    mode: "0644"
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version is version('22.04', '>=')
+    - postgresql_use_official_repo | bool
+
+- name: Configure PostgreSQL apt repository
+  ansible.builtin.apt_repository:
+    repo: "{{ postgresql_repo }}"
+    filename: postgresql
+    state: present
+  register: postgresql_repo_config
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version is version('22.04', '>=')
+    - postgresql_use_official_repo | bool
+
+- name: Refresh apt cache if repository was added
+  ansible.builtin.apt:
+    update_cache: true
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version is version('22.04', '>=')
+    - postgresql_use_official_repo | bool
+    - postgresql_repo_config is defined
+    - postgresql_repo_config is changed
+
+- name: Set package list for PostgreSQL
+  ansible.builtin.set_fact:
+    postgresql_packages: "{{ (postgresql_packages_base + postgresql_extra_packages) | unique | list }}"
+
+- name: Install PostgreSQL packages
+  ansible.builtin.apt:
+    name: "{{ postgresql_packages | list }}"
+    state: present
+    update_cache: true
+  when:
+    - ansible_os_family == 'Debian'
+
+- name: Ensure PostgreSQL service is enabled and started
+  ansible.builtin.systemd:
+    name: "{{ postgresql_service_name }}"
+    enabled: true
+    state: started
+
+- name: Gather facts for PostgreSQL configuration files
+  ansible.builtin.stat:
+    path: "{{ postgresql_conf_path }}"
+  register: postgresql_conf_file
+
+- name: Configure listen_addresses in postgresql.conf
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_conf_path }}"
+    regexp: '^#?listen_addresses\s*='
+    line: "listen_addresses = '{{ postgresql_listen_addresses }}'"
+  when: postgresql_conf_file.stat.exists
+  notify: Restart PostgreSQL
+
+- name: Configure port in postgresql.conf
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_conf_path }}"
+    regexp: '^#?port\s*='
+    line: "port = {{ postgresql_port }}"
+  when: postgresql_conf_file.stat.exists
+  notify: Restart PostgreSQL
+
+- name: Configure password_encryption in postgresql.conf
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_conf_path }}"
+    regexp: '^#?password_encryption\s*='
+    line: "password_encryption = '{{ postgresql_password_encryption }}'"
+  when:
+    - postgresql_conf_file.stat.exists
+    - postgresql_password_encryption | length > 0
+  notify: Restart PostgreSQL
+
+- name: Ensure pg_hba.conf exists
+  ansible.builtin.stat:
+    path: "{{ postgresql_hba_path }}"
+  register: postgresql_hba_file
+
+- name: Configure pg_hba.conf access rules
+  ansible.builtin.blockinfile:
+    path: "{{ postgresql_hba_path }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR POSTGRESQL ACCESS"
+    block: |-
+      {% for network in postgresql_allowed_hosts %}
+      host    all             all             {{ network }}        {{ postgresql_auth_method }}
+      {% endfor %}
+  when:
+    - postgresql_hba_file.stat.exists
+    - postgresql_allowed_hosts | length > 0
+  notify: Restart PostgreSQL
+
+- name: Remove managed pg_hba.conf block when no networks are defined
+  ansible.builtin.blockinfile:
+    path: "{{ postgresql_hba_path }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR POSTGRESQL ACCESS"
+    state: absent
+  when:
+    - postgresql_hba_file.stat.exists
+    - postgresql_allowed_hosts | length == 0


### PR DESCRIPTION
## Summary
- add a PostgreSQL vhost role that provisions packages, repositories, and basic configuration suitable for Ubuntu 22.04+
- provide a deploy_postgres_vhosts playbook that wires the new role with the shared common role

## Testing
- `ansible-playbook -i inventory/hosts/all playbooks/deploy_postgres_vhosts.yml --syntax-check` *(fails: ansible-playbook not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5baeb2d483329fa49a17c3ca3bce