### PR TITLE
Add XControl server playbook and role

### DIFF
--- a/playbooks/deploy_xcontrol_server._vhosts.yml
+++ b/playbooks/deploy_xcontrol_server._vhosts.yml
@@ -1,0 +1,8 @@
+- name: setup xcontrol server
+  hosts: cn-homepage.svc.plus
+  become: true
+  vars:
+    group: cn-homepage.svc.plus
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/xcontrol_server/

--- a/playbooks/roles/vhosts/xcontrol_server/defaults/main.yml
+++ b/playbooks/roles/vhosts/xcontrol_server/defaults/main.yml
@@ -1,0 +1,7 @@
+xcontrol_config_dir: /etc/XControl
+xcontrol_config_filename: server-qwen-ai.yaml
+xcontrol_service_name: xcontrol-server
+xcontrol_service_unit: xcontrol-server.service
+xcontrol_service_user: root
+xcontrol_service_group: root
+xcontrol_binary_path: /usr/bin/xcontrol-server

--- a/playbooks/roles/vhosts/xcontrol_server/tasks/main.yml
+++ b/playbooks/roles/vhosts/xcontrol_server/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Ensure XControl configuration directory exists
+  ansible.builtin.file:
+    path: "{{ xcontrol_config_dir }}"
+    state: directory
+    owner: "{{ xcontrol_service_user }}"
+    group: "{{ xcontrol_service_group }}"
+    mode: '0755'
+  when: inventory_hostname in groups[group]
+
+- name: Deploy XControl server configuration
+  ansible.builtin.template:
+    src: server-qwen-ai.yaml.j2
+    dest: "{{ xcontrol_config_dir }}/{{ xcontrol_config_filename }}"
+    owner: "{{ xcontrol_service_user }}"
+    group: "{{ xcontrol_service_group }}"
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Install XControl server systemd service
+  ansible.builtin.template:
+    src: xcontrol-server.service.j2
+    dest: "/etc/systemd/system/{{ xcontrol_service_unit }}"
+    mode: '0644'
+  when: inventory_hostname in groups[group]
+
+- name: Enable and restart XControl server
+  ansible.builtin.systemd:
+    name: "{{ xcontrol_service_name }}"
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: inventory_hostname in groups[group]

--- a/playbooks/roles/vhosts/xcontrol_server/templates/server-qwen-ai.yaml.j2
+++ b/playbooks/roles/vhosts/xcontrol_server/templates/server-qwen-ai.yaml.j2
@@ -1,0 +1,55 @@
+global:
+  #proxy: socks5://127.0.0.1:1080
+  redis:
+    addr: "127.0.0.1:6379"
+    password: ""
+  vectordb:
+    pgurl: "postgres://shenlan:password@127.0.0.1:5432/shenlan"
+  datasources:
+    - name: Xstream
+      repo: https://github.com/svc-design/Xstream
+      path: docs
+    - name: XControl
+      repo: https://github.com/svc-design/XControl
+      path: docs
+    - name: documents
+      repo: https://github.com/svc-design/documents
+      path: /
+
+sync:
+  repo:
+    proxy: socks5://127.0.0.1:1080
+
+models:
+  embedder:
+    provider: "openai"
+    models: "text-embedding-v4"
+    baseurl: "https://dashscope.aliyuncs.com/compatible-mode"
+    endpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+    token: "sk-9c3643548e4e40bd8936cba62cc35aeb"
+  generator:
+    provider: "chutes"
+    models:
+      - 'unsloth/Llama-3.2-3B-Instruct'
+    baseurl: "https://llm.chutes.ai"
+    endpoint: "https://llm.chutes.ai/v1/chat/completions"
+    token: "cpk_9221badbda89490ea8f2fe8f3818eebc.5bd47a04456b5f9f94b88066fd18faa2.2jsXIytq11GcDmXpEGNd1ls2zeQWn4US"
+
+embedding:
+  max_batch: 64
+  dimension: 1024
+  max_chars: 8000
+  rate_limit_tpm: 120000
+
+chunking:
+  embed_toc: true
+  max_tokens: 800
+  overlap_tokens: 80
+  prefer_heading_split: true
+  include_exts: [".md", ".mdx"]
+  ignore_dirs: [".git", "node_modules", "dist", "build"]
+
+api:
+  askai:
+    timeout: 100
+    retries: 3

--- a/playbooks/roles/vhosts/xcontrol_server/templates/xcontrol-server.service.j2
+++ b/playbooks/roles/vhosts/xcontrol_server/templates/xcontrol-server.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=XControl Server (Qwen AI)
+After=network.target
+
+[Service]
+User={{ xcontrol_service_user }}
+Group={{ xcontrol_service_group }}
+ExecStart={{ xcontrol_binary_path }} --config {{ xcontrol_config_dir }}/{{ xcontrol_config_filename }}
+WorkingDirectory={{ xcontrol_config_dir }}
+Restart=on-failure
+RestartSec=5s
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an Ansible playbook to deploy the XControl server on the cn-homepage.svc.plus host
- create an XControl server role that installs the configuration file and systemd unit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd60de69488332a607b566af092890