### PR TITLE
Refine otel collector configuration variables

### DIFF
--- a/playbooks/deploy_exporters_vhosts.yml
+++ b/playbooks/deploy_exporters_vhosts.yml
@@ -3,32 +3,88 @@
   become: true
   vars:
     group: web
+    otlp_endpoint: &otel_endpoint https://otel.svc.plus/api/default/
+    otlp_auth: &otel_auth "Basic cm9vdEBleGFtcGxlLmNvbTpRN01wRjZBTzZFelRjRjdJ"
+    otel_prometheus_node_static_configs: &otel_node_static_configs
+      - targets: ['172.31.2.33:9100']
+        labels:
+          vendor: aws
+          account: prod
+          group: core
+          name: tky-proxy.svc.plus
+          iid: '172.31.2.33'
+      - targets: ['167.179.72.223:9100']
+        labels:
+          vendor: aws
+          account: prod
+          group: web-system
+          name: global-homepage.svc.plus
+          iid: '167.179.72.223'
+      - targets: ['47.120.61.35:9100']
+        labels:
+          vendor: alicloud
+          account: prod
+          group: web-system
+          name: cn-homepage.svc.plus
+          iid: '47.120.61.35'
+    otel_prometheus_process_static_configs: &otel_process_static_configs
+      - targets: ['172.31.2.33:9256']
+        labels:
+          vendor: aws
+          account: prod
+          group: core
+          name: tky-proxy.svc.plus
+          iid: '172.31.2.33'
+      - targets: ['167.179.72.223:9256']
+        labels:
+          vendor: aws
+          account: prod
+          group: web-system
+          name: global-homepage.svc.plus
+          iid: '167.179.72.223'
+      - targets: ['47.120.61.35:9256']
+        labels:
+          vendor: alicloud
+          account: prod
+          group: web-system
+          name: cn-homepage.svc.plus
+          iid: '47.120.61.35'
     exporters:
-      endpoint: https://otel.svc.plus/api/default/
+      endpoint: *otel_endpoint
   roles:
     - roles/vhosts/common/
     - roles/vhosts/node_exporter/
     - roles/vhosts/process_exporter/
     - roles/vhosts/otel-collector/
+
 - name: setup otel exporters
   hosts: global-homepage.svc.plus
   become: true
   vars:
     group: web
+    otlp_endpoint: *otel_endpoint
+    otlp_auth: *otel_auth
+    otel_prometheus_node_static_configs: *otel_node_static_configs
+    otel_prometheus_process_static_configs: *otel_process_static_configs
     exporters:
-      endpoint: https://otel.svc.plus/api/default/
+      endpoint: *otel_endpoint
   roles:
     - roles/vhosts/common/
     - roles/vhosts/node_exporter/
     - roles/vhosts/process_exporter/
     - roles/vhosts/otel-collector/
+
 - name: setup otel exporters
   hosts: otel.svc.plus
   become: true
   vars:
     group: web
+    otlp_endpoint: *otel_endpoint
+    otlp_auth: *otel_auth
+    otel_prometheus_node_static_configs: *otel_node_static_configs
+    otel_prometheus_process_static_configs: *otel_process_static_configs
     exporters:
-      endpoint: https://otel.svc.plus/api/default/
+      endpoint: *otel_endpoint
   roles:
     - roles/vhosts/node_exporter/
     - roles/vhosts/process_exporter/

--- a/playbooks/deploy_vhosts_otel-collector.yml
+++ b/playbooks/deploy_vhosts_otel-collector.yml
@@ -3,6 +3,52 @@
   become: true
   vars:
     group: web
+    otlp_endpoint: https://otel.svc.plus/api/default/
+    otlp_auth: "Basic cm9vdEBleGFtcGxlLmNvbTpRN01wRjZBTzZFelRjRjdJ"
+    otel_prometheus_node_static_configs:
+      - targets: ['172.31.2.33:9100']
+        labels:
+          vendor: aws
+          account: prod
+          group: core
+          name: tky-proxy.svc.plus
+          iid: '172.31.2.33'
+      - targets: ['167.179.72.223:9100']
+        labels:
+          vendor: aws
+          account: prod
+          group: web-system
+          name: global-homepage.svc.plus
+          iid: '167.179.72.223'
+      - targets: ['47.120.61.35:9100']
+        labels:
+          vendor: alicloud
+          account: prod
+          group: web-system
+          name: cn-homepage.svc.plus
+          iid: '47.120.61.35'
+    otel_prometheus_process_static_configs:
+      - targets: ['172.31.2.33:9256']
+        labels:
+          vendor: aws
+          account: prod
+          group: core
+          name: tky-proxy.svc.plus
+          iid: '172.31.2.33'
+      - targets: ['167.179.72.223:9256']
+        labels:
+          vendor: aws
+          account: prod
+          group: web-system
+          name: global-homepage.svc.plus
+          iid: '167.179.72.223'
+      - targets: ['47.120.61.35:9256']
+        labels:
+          vendor: alicloud
+          account: prod
+          group: web-system
+          name: cn-homepage.svc.plus
+          iid: '47.120.61.35'
     exporters:
       endpoint: https://otel.svc.plus/api/default/
   roles:

--- a/playbooks/roles/vhosts/otel-collector/tasks/main.yml
+++ b/playbooks/roles/vhosts/otel-collector/tasks/main.yml
@@ -78,6 +78,15 @@
 #     - inventory_hostname in groups[group]
 #     - ansible_os_family == 'Debian'
 
+# === Configuration validation ===
+- name: Ensure OpenObserve authorization is provided
+  ansible.builtin.assert:
+    that:
+      - otlp_auth is defined
+      - otlp_auth | string | trim | length > 0
+    fail_msg: otlp_auth must be defined and non-empty for otel collector deployment
+  when: inventory_hostname in groups[group]
+
 - name: Deploy otel collector config
   ansible.builtin.template:
     src: otel-config.yaml

--- a/playbooks/roles/vhosts/otel-collector/templates/otel-config.yaml
+++ b/playbooks/roles/vhosts/otel-collector/templates/otel-config.yaml
@@ -1,3 +1,6 @@
+{% set node_static_configs = otel_prometheus_node_static_configs | mandatory('otel_prometheus_node_static_configs must be provided') %}
+{% set process_static_configs = otel_prometheus_process_static_configs | mandatory('otel_prometheus_process_static_configs must be provided') %}
+
 receivers:
   prometheus:
     config:
@@ -6,22 +9,22 @@ receivers:
       scrape_configs:
         - job_name: 'node-exporter'
           static_configs:
-            - targets: ['localhost:9100']
+{% for static_config in node_static_configs %}
+            - targets: {{ static_config.targets | to_json }}
               labels:
-                vendor:  '{{ otel_vendor | default("aws") }}'
-                account: '{{ otel_account | default("prod") }}'
-                group:   '{{ otel_group | default("core") }}'
-                name:    '{{ otel_name | default(inventory_hostname) }}'
-                iid:     '{{ otel_iid | default(ansible_default_ipv4.address) }}'
+{% for label_key, label_value in static_config.labels.items() %}
+                {{ label_key }}: '{{ label_value }}'
+{% endfor %}
+{% endfor %}
         - job_name: 'process-exporter'
           static_configs:
-            - targets: ['localhost:9256']
+{% for static_config in process_static_configs %}
+            - targets: {{ static_config.targets | to_json }}
               labels:
-                vendor:  '{{ otel_vendor | default("aws") }}'
-                account: '{{ otel_account | default("prod") }}'
-                group:   '{{ otel_group | default("core") }}'
-                name:    '{{ otel_name | default(inventory_hostname) }}'
-                iid:     '{{ otel_iid | default(ansible_default_ipv4.address) }}'
+{% for label_key, label_value in static_config.labels.items() %}
+                {{ label_key }}: '{{ label_value }}'
+{% endfor %}
+{% endfor %}
   journald:
     directory: /var/log/journal
   filelog/std:
@@ -47,11 +50,11 @@ exporters:
   otlphttp/openobserve:
     endpoint: {{ otlp_endpoint | default('https://otel.svc.plus/api/default/') }}
     headers:
-      Authorization: "{{ otlp_auth | default('Basic cm9vdEBleGFtcGxlLmNvbTpiNTVkbHFLenVLamZXVXRY') }}"
+      Authorization: "{{ otlp_auth }}"
   otlphttp/openobserve_journald:
     endpoint: {{ otlp_endpoint | default('https://otel.svc.plus/api/default/') }}
     headers:
-      Authorization: "{{ otlp_auth | default('Basic cm9vdEBleGFtcGxlLmNvbTpiNTVkbHFLenVLamZXVXRY') }}"
+      Authorization: "{{ otlp_auth }}"
       stream-name: journald
 
 service:


### PR DESCRIPTION
## Summary
- require the otel collector role to receive explicit Prometheus scrape targets via playbook variables instead of hard-coded template defaults
- move the OpenObserve authorization header to playbook vars and validate it is supplied before templating
- keep the otlp endpoint configurable while removing the legacy authorization default from the collector template

## Testing
- `ansible-playbook -i inventory/hosts --syntax-check playbooks/deploy_exporters_vhosts.yml` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6c7c9f848332b97635b7b5906ab2