### PR TITLE
feat: add blackbox exporter vhost role

### DIFF
--- a/playbooks/deploy_blackbox_exporters_vhosts.yml
+++ b/playbooks/deploy_blackbox_exporters_vhosts.yml
@@ -1,0 +1,20 @@
+- name: Deploy blackbox exporter
+  hosts: dl.svc.plus
+  become: true
+  vars:
+    blackbox_version: "0.25.0"
+    blackbox_user: "blackbox"
+    blackbox_bin: "/usr/local/bin/blackbox_exporter"
+    blackbox_conf_dir: "/opt/blackbox"
+    blackbox_conf_file: "/opt/blackbox/blackbox.yml"
+    blackbox_listen: ":9115"
+    dl_business_host: "dl.svc.plus"
+    dl_download_path: "/download/"
+    blackbox_arch_map:
+      x86_64: linux-amd64
+      amd64: linux-amd64
+      aarch64: linux-arm64
+      arm64: linux-arm64
+  roles:
+    - roles/vhosts/common/
+    - roles/vhosts/blackbox_exporter/

--- a/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+blackbox_arch_map:
+  x86_64: linux-amd64
+  amd64: linux-amd64
+  aarch64: linux-arm64
+  arm64: linux-arm64

--- a/playbooks/roles/vhosts/blackbox_exporter/meta/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+- name: Compute archive information
+  ansible.builtin.set_fact:
+    blackbox_archive_arch: "{{ (blackbox_arch_map | default({})).get((ansible_architecture | lower), 'linux-amd64') }}"
+    blackbox_archive_name: "blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}"
+    blackbox_archive_file: "/tmp/{{ blackbox_archive_name }}.tar.gz"
+
+- name: Ensure user exists
+  ansible.builtin.user:
+    name: "{{ blackbox_user }}"
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+
+- name: Create config dir
+  ansible.builtin.file:
+    path: "{{ blackbox_conf_dir }}"
+    state: directory
+    owner: "{{ blackbox_user }}"
+    group: "{{ blackbox_user }}"
+    mode: "0750"
+
+- name: Download blackbox_exporter tarball
+  ansible.builtin.get_url:
+    url: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_version }}/{{ blackbox_archive_name }}.tar.gz"
+    dest: "{{ blackbox_archive_file }}"
+    mode: "0644"
+
+- name: Unpack archive
+  ansible.builtin.unarchive:
+    src: "{{ blackbox_archive_file }}"
+    dest: "/tmp"
+    remote_src: true
+  register: unpack
+
+- name: Install binary
+  ansible.builtin.copy:
+    src: "/tmp/{{ blackbox_archive_name }}/blackbox_exporter"
+    dest: "{{ blackbox_bin }}"
+    mode: "0755"
+    owner: "root"
+    group: "root"
+  when: unpack is changed
+
+- name: Render blackbox configuration
+  ansible.builtin.template:
+    src: "blackbox.yml.j2"
+    dest: "{{ blackbox_conf_file }}"
+    owner: "{{ blackbox_user }}"
+    group: "{{ blackbox_user }}"
+    mode: "0640"
+  notify: Restart blackbox
+
+- name: Install systemd unit
+  ansible.builtin.template:
+    src: "blackbox.service.j2"
+    dest: "/etc/systemd/system/blackbox.service"
+    mode: "0644"
+  notify:
+    - Daemon reload
+    - Restart blackbox
+
+- name: Enable and start service
+  ansible.builtin.systemd:
+    name: blackbox
+    enabled: true
+    state: started
+
+- name: Daemon reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: Daemon reload
+
+- name: Restart blackbox
+  ansible.builtin.systemd:
+    name: blackbox
+    state: restarted
+  listen: Restart blackbox

--- a/playbooks/roles/vhosts/blackbox_exporter/templates/blackbox.service.j2
+++ b/playbooks/roles/vhosts/blackbox_exporter/templates/blackbox.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus Blackbox Exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ blackbox_user }}
+Group={{ blackbox_user }}
+ExecStart={{ blackbox_bin }} \
+  --config.file={{ blackbox_conf_file }} \
+  --web.listen-address={{ blackbox_listen }}
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/vhosts/blackbox_exporter/templates/blackbox.yml.j2
+++ b/playbooks/roles/vhosts/blackbox_exporter/templates/blackbox.yml.j2
@@ -1,0 +1,15 @@
+modules:
+  http_dl_download:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      follow_redirects: true
+      valid_status_codes: [200, 302]
+      headers:
+        Host: {{ dl_business_host }}
+      tls_config:
+        server_name: {{ dl_business_host }}
+        insecure_skip_verify: false
+      # fail_if_body_not_matches_regexp:
+      #   - "(?i)\\.zip|\\.tar\\.gz|manifest"


### PR DESCRIPTION
## Summary
- add a blackbox exporter vhost role with architecture-aware downloads and service management
- provide templates for the exporter configuration and systemd unit tuned for the download host
- create a deployment playbook wiring the new role with its required variables

## Testing
- not run (tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf71698fa08332b1706688da06c9c7