### PR TITLE
Fix blackbox exporter role handlers

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/handlers/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Daemon reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: Daemon reload
+
+- name: Restart blackbox
+  ansible.builtin.systemd:
+    name: blackbox
+    state: restarted
+  listen: Restart blackbox

--- a/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
@@ -65,14 +65,3 @@
     name: blackbox
     enabled: true
     state: started
-
-- name: Daemon reload
-  ansible.builtin.systemd:
-    daemon_reload: true
-  listen: Daemon reload
-
-- name: Restart blackbox
-  ansible.builtin.systemd:
-    name: blackbox
-    state: restarted
-  listen: Restart blackbox


### PR DESCRIPTION
## Summary
- move handler tasks for the blackbox exporter role into a proper handlers file
- keep the main task file focused on setup and service management without invalid attributes

## Testing
- ansible-playbook -i playbooks/inventory.ini playbooks/deploy_blackbox_exporters_vhosts.yml -D -C *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d205338524833285354567854d2263