### PR TITLE
Fix blackbox_exporter handler syntax

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/handlers/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/handlers/main.yml
@@ -2,10 +2,8 @@
 - name: Daemon reload
   ansible.builtin.systemd:
     daemon_reload: true
-  listen: Daemon reload
 
 - name: Restart blackbox
   ansible.builtin.systemd:
     name: blackbox
     state: restarted
-  listen: Restart blackbox


### PR DESCRIPTION
## Summary
- remove unsupported listen attributes from blackbox_exporter handlers to resolve ansible parsing error

## Testing
- ansible-lint playbooks/roles/vhosts/blackbox_exporter *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d20dd48c808332aa19cf6920c3a101