### PR TITLE
Configure PostgreSQL repo via common role

### DIFF
--- a/playbooks/deploy_postgre_vhosts.yml
+++ b/playbooks/deploy_postgre_vhosts.yml
@@ -1,10 +1,29 @@
 - name: Setup postgres server
   hosts: cn-homepage.svc.plus
   become: true
+  vars:
+    group: cn-homepage.svc.plus
+    repo_setup: true
+    repos: &postgresql_common_repos
+      - name: postgresql
+        uri: "http://apt.postgresql.org/pub/repos/apt"
+        suite: "{{ ansible_distribution_release }}-pgdg"
+        components: ["main"]
+        key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+        enabled: true
+    postgresql_use_official_repo: false
   roles:
-    - roles/vhosts/postgres
+    - roles/vhosts/common/
+    - roles/vhosts/postgres/
+
 - name: Setup postgres server
   hosts: global-homepage.svc.plus
   become: true
+  vars:
+    group: global-homepage.svc.plus
+    repo_setup: true
+    repos: *postgresql_common_repos
+    postgresql_use_official_repo: false
   roles:
+    - roles/vhosts/common/
     - roles/vhosts/postgres/


### PR DESCRIPTION
## Summary
- ensure the PostgreSQL APT repository is managed via the common role
- add repository configuration variables to the PostgreSQL vhost playbook and disable the role-local repo setup

## Testing
- `ansible-playbook --syntax-check playbooks/deploy_postgre_vhosts.yml` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b50fd7e8833299afceecd8afef9e