### PR TITLE
Add Node.js vhost role for macOS and Ubuntu

### DIFF
--- a/playbooks/deploy_nodejs_vhosts.yml
+++ b/playbooks/deploy_nodejs_vhosts.yml
@@ -1,0 +1,8 @@
+---
+- name: Configure Node.js runtime for vhosts
+  hosts: nodejs_vhosts
+  gather_facts: true
+  vars:
+    nodejs_major_version: 22
+  roles:
+    - roles/vhosts/nodejs

--- a/playbooks/roles/vhosts/nodejs/tasks/darwin.yml
+++ b/playbooks/roles/vhosts/nodejs/tasks/darwin.yml
@@ -1,0 +1,38 @@
+---
+- name: Determine Homebrew prefix
+  ansible.builtin.set_fact:
+    nodejs_homebrew_prefix: "{{ '/opt/homebrew' if ansible_facts['architecture'] in ['arm64', 'aarch64'] else '/usr/local' }}"
+    nodejs_homebrew_formula: "node@{{ nodejs_major_version | default(22) }}"
+
+- name: Ensure unversioned Homebrew node formula is absent
+  community.general.homebrew:
+    name: node
+    state: absent
+
+- name: Ensure Homebrew {{ nodejs_homebrew_formula }} formula is installed
+  community.general.homebrew:
+    name: "{{ nodejs_homebrew_formula }}"
+    state: present
+
+- name: Ensure {{ nodejs_homebrew_formula }} is linked as the default node
+  ansible.builtin.command: "brew link --force --overwrite {{ nodejs_homebrew_formula }}"
+  register: nodejs_brew_link
+  changed_when: "'linking' in (nodejs_brew_link.stdout | lower)"
+  failed_when: nodejs_brew_link.rc != 0 and 'already linked' not in (nodejs_brew_link.stdout | lower) and 'already linked' not in (nodejs_brew_link.stderr | lower)
+  environment:
+    PATH: "{{ nodejs_homebrew_prefix }}/bin:/usr/local/bin:/usr/bin:/bin"
+
+- name: Prioritize {{ nodejs_homebrew_formula }} binaries in the default shell path
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    line: "export PATH=\"{{ nodejs_homebrew_prefix }}/opt/{{ nodejs_homebrew_formula }}/bin:$PATH\""
+    insertafter: EOF
+    create: true
+
+- name: Pin {{ nodejs_homebrew_formula }} to prevent automatic upgrades
+  ansible.builtin.command: "brew pin {{ nodejs_homebrew_formula }}"
+  register: nodejs_brew_pin
+  changed_when: "'pinned' in (nodejs_brew_pin.stdout | lower)"
+  failed_when: nodejs_brew_pin.rc != 0 and 'already pinned' not in (nodejs_brew_pin.stdout | lower) and 'already pinned' not in (nodejs_brew_pin.stderr | lower)
+  environment:
+    PATH: "{{ nodejs_homebrew_prefix }}/bin:/usr/local/bin:/usr/bin:/bin"

--- a/playbooks/roles/vhosts/nodejs/tasks/main.yml
+++ b/playbooks/roles/vhosts/nodejs/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Include macOS tasks
+  ansible.builtin.include_tasks: darwin.yml
+  when: ansible_facts['os_family'] == 'Darwin'
+
+- name: Include Ubuntu tasks
+  ansible.builtin.include_tasks: ubuntu.yml
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Ubuntu'
+
+- name: Fail for unsupported platforms
+  ansible.builtin.fail:
+    msg: "The nodejs role currently supports macOS and Ubuntu only."
+  when: ansible_facts['os_family'] not in ['Darwin', 'Debian'] or (ansible_facts['os_family'] == 'Debian' and ansible_facts['distribution'] != 'Ubuntu')

--- a/playbooks/roles/vhosts/nodejs/tasks/ubuntu.yml
+++ b/playbooks/roles/vhosts/nodejs/tasks/ubuntu.yml
@@ -1,0 +1,53 @@
+---
+- name: Ensure prerequisite packages are installed
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+  become: true
+
+- name: Ensure directory for apt keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Download NodeSource GPG key
+  ansible.builtin.get_url:
+    url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+    dest: /etc/apt/keyrings/nodesource.gpg
+    mode: '0644'
+  register: nodesource_key
+  become: true
+
+- name: Configure NodeSource Node.js {{ nodejs_major_version | default(22) }}.x repository
+  ansible.builtin.copy:
+    dest: "/etc/apt/sources.list.d/nodesource-node{{ nodejs_major_version | default(22) }}.list"
+    content: |
+      deb [signed-by=/etc/apt/keyrings/nodesource.gpg arch=amd64,arm64] https://deb.nodesource.com/node_{{ nodejs_major_version | default(22) }}.x nodistro main
+    mode: '0644'
+  register: nodesource_repo
+  become: true
+
+- name: Update apt cache for NodeSource repository
+  ansible.builtin.apt:
+    update_cache: true
+  when: nodesource_key.changed or nodesource_repo.changed
+  become: true
+
+- name: Ensure Node.js {{ nodejs_major_version | default(22) }}.x is installed
+  ansible.builtin.apt:
+    name: nodejs
+    state: present
+    update_cache: true
+  become: true
+
+- name: Hold Node.js package to prevent automatic upgrades
+  ansible.builtin.dpkg_selections:
+    name: nodejs
+    selection: hold
+  become: true


### PR DESCRIPTION
## Summary
- add a reusable nodejs vhost role that provisions Node.js 22 LTS on macOS (Homebrew) and Ubuntu (NodeSource)
- provide a deploy_nodejs_vhosts playbook that targets hosts needing the runtime
- expose the Node.js major version as a playbook variable and apply it across macOS and Ubuntu tasks

## Testing
- ⚠️ `ansible-playbook -i inventory/hosts/all --syntax-check playbooks/deploy_nodejs_vhosts.yml` *(fails: ansible-playbook not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d33aaa62a08332919803090d5e16b6