### PR TITLE
Fix blackbox exporter archive facts handling

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
@@ -10,3 +10,5 @@ blackbox_arch_map:
   amd64: linux-amd64
   aarch64: linux-arm64
   arm64: linux-arm64
+blackbox_download_base_url: "https://github.com/prometheus/blackbox_exporter/releases/download"
+blackbox_tmp_dir: "/tmp"

--- a/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
@@ -6,7 +6,8 @@
 - name: Compute archive information
   ansible.builtin.set_fact:
     blackbox_archive_name: "blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}"
-    blackbox_archive_file: "/tmp/{{ blackbox_archive_name }}.tar.gz"
+    blackbox_archive_file: "{{ blackbox_tmp_dir }}/blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}.tar.gz"
+    blackbox_archive_url: "{{ blackbox_download_base_url }}/v{{ blackbox_version }}/blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}.tar.gz"
 
 - name: Ensure user exists
   ansible.builtin.user:
@@ -25,20 +26,20 @@
 
 - name: Download blackbox_exporter tarball
   ansible.builtin.get_url:
-    url: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_version }}/{{ blackbox_archive_name }}.tar.gz"
+    url: "{{ blackbox_archive_url }}"
     dest: "{{ blackbox_archive_file }}"
     mode: "0644"
 
 - name: Unpack archive
   ansible.builtin.unarchive:
     src: "{{ blackbox_archive_file }}"
-    dest: "/tmp"
+    dest: "{{ blackbox_tmp_dir }}"
     remote_src: true
   register: unpack
 
 - name: Install binary
   ansible.builtin.copy:
-    src: "/tmp/{{ blackbox_archive_name }}/blackbox_exporter"
+    src: "{{ blackbox_tmp_dir }}/{{ blackbox_archive_name }}/blackbox_exporter"
     dest: "{{ blackbox_bin }}"
     mode: "0755"
     owner: "root"


### PR DESCRIPTION
## Summary
- add defaults for the download base URL and temporary directory in the blackbox exporter role
- compute archive metadata without self-referential facts and reuse the new defaults when downloading and unpacking the exporter

## Testing
- not run (ansible-playbook not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9f8ab27f88332b5e04ea8915af295