### PR TITLE
Update blackbox exporter download URL

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
@@ -10,5 +10,5 @@ blackbox_arch_map:
   amd64: linux-amd64
   aarch64: linux-arm64
   arm64: linux-arm64
-blackbox_download_base_url: "https://github.com/prometheus/blackbox_exporter/releases/download"
+blackbox_download_base_url: "https://dl.svc.plus/prometheus/blackbox_exporter"
 blackbox_tmp_dir: "/tmp"

--- a/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.set_fact:
     blackbox_archive_name: "blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}"
     blackbox_archive_file: "{{ blackbox_tmp_dir }}/blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}.tar.gz"
-    blackbox_archive_url: "{{ blackbox_download_base_url }}/v{{ blackbox_version }}/blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}.tar.gz"
+    blackbox_archive_url: "{{ blackbox_download_base_url }}/{{ blackbox_version }}/blackbox_exporter-{{ blackbox_version }}.{{ blackbox_archive_arch }}.tar.gz"
 
 - name: Ensure user exists
   ansible.builtin.user:


### PR DESCRIPTION
## Summary
- point the blackbox exporter role to the dl.svc.plus download mirror
- adjust archive URL construction to match the mirror's versioned path structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da0b8400188332917931ab39a603a7