### PR TITLE
Fix blackbox exporter install from remote archive

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/tasks/main.yml
@@ -44,6 +44,7 @@
     mode: "0755"
     owner: "root"
     group: "root"
+    remote_src: true
   when: unpack is changed
 
 - name: Render blackbox configuration


### PR DESCRIPTION
## Summary
- ensure the blackbox exporter binary installation copies from the remote extraction directory by enabling `remote_src`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da815b91f483329f9cd3043800b448