### PR TITLE
Set default dl business host for blackbox exporter role

### DIFF
--- a/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
+++ b/playbooks/roles/vhosts/blackbox_exporter/defaults/main.yml
@@ -12,3 +12,4 @@ blackbox_arch_map:
   arm64: linux-arm64
 blackbox_download_base_url: "https://dl.svc.plus/prometheus/blackbox_exporter"
 blackbox_tmp_dir: "/tmp"
+dl_business_host: "dl.svc.plus"


### PR DESCRIPTION
## Summary
- add a default `dl_business_host` value for the blackbox exporter role to match the vhost configuration

## Testing
- ansible-playbook playbooks/deploy_blackbox_exporters_vhosts.yml --syntax-check *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa9a19c048332bc78e88b525cc0a5