### PR TITLE
Add playbook to install Docker on supported hosts

### DIFF
--- a/playbooks/roles/vhosts/docker/defaults/main.yml
+++ b/playbooks/roles/vhosts/docker/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Default Docker repository channel
+# Available options: stable, test, nightly
+# Default is stable
+
+# The channel used when configuring Docker repositories.
+docker_channel: stable

--- a/playbooks/roles/vhosts/docker/meta/main.yml
+++ b/playbooks/roles/vhosts/docker/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/playbooks/roles/vhosts/docker/tasks/main.yml
+++ b/playbooks/roles/vhosts/docker/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Detect supported platform
+  ansible.builtin.set_fact:
+    docker_platform: >-
+      {{
+        'ubuntu' if ansible_distribution == 'Ubuntu' and ansible_distribution_version in ['22.04', '24.04']
+        else 'rocky' if ansible_distribution == 'Rocky' and (ansible_distribution_major_version | int) in [8, 9, 10]
+        else 'unsupported'
+      }}
+
+- name: Determine repository architecture
+  ansible.builtin.set_fact:
+    docker_repo_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Ensure platform is supported
+  ansible.builtin.assert:
+    that: docker_platform != 'unsupported'
+    fail_msg: >-
+      Docker installation is only supported on Ubuntu 22.04/24.04 and Rocky Linux 8/9/10.
+
+- name: Install Docker on Ubuntu
+  when: docker_platform == 'ubuntu'
+  block:
+    - name: Install required packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+          - lsb-release
+        state: present
+        update_cache: true
+
+    - name: Ensure apt keyring directory exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: Add Docker GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: '0644'
+
+    - name: Add Docker repository
+      ansible.builtin.apt_repository:
+        repo: >-
+          deb [arch={{ docker_repo_arch }} signed-by=/etc/apt/keyrings/docker.asc]
+          https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} {{ docker_channel }}
+        state: present
+        filename: docker
+
+    - name: Install Docker Engine packages
+      ansible.builtin.apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+        update_cache: true
+
+- name: Install Docker on Rocky Linux
+  when: docker_platform == 'rocky'
+  block:
+    - name: Install required packages
+      ansible.builtin.package:
+        name:
+          - dnf-plugins-core
+          - yum-utils
+        state: present
+
+    - name: Configure Docker repository
+      ansible.builtin.yum_repository:
+        name: docker-ce
+        description: Docker CE Repository
+        baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/{{ docker_channel }}
+        enabled: true
+        gpgcheck: true
+        gpgkey: https://download.docker.com/linux/centos/gpg
+
+    - name: Install Docker Engine packages
+      ansible.builtin.package:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+
+- name: Ensure Docker service is enabled and running
+  ansible.builtin.service:
+    name: docker
+    state: started
+    enabled: true

--- a/playbooks/setup-docker.yml
+++ b/playbooks/setup-docker.yml
@@ -1,0 +1,5 @@
+- name: Setup Docker Engine
+  hosts: all
+  become: true
+  roles:
+    - roles/vhosts/docker


### PR DESCRIPTION
## Summary
- add a reusable setup-docker playbook
- provide a Docker role that configures official repositories for Ubuntu 22.04/24.04 and Rocky 8/9/10 using the stable channel by default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d855effa8833284a93f67e4c6e87d)