### PR TITLE
Initialize placeholder docker and chart roles

### DIFF
--- a/playbooks/roles/README.md
+++ b/playbooks/roles/README.md
@@ -1,0 +1,33 @@
+# Playbook roles planning
+
+This document clarifies what should live under `/playbooks/roles/` for host-level automation (Ansible) versus what should be delivered through Helm charts, and ensures we cover the five tiers across data platforms: data warehouse → big data → ML → DL → large models.
+
+## Scope rules
+- **Ansible roles**: host-coupled configuration that is not itself a cloud resource (GPU driver/runtime, OS tuning, user/SSH prep, rendering on-host config files, database bootstrapping, etc.).
+- **Helm charts**: anything that runs as a Kubernetes workload (operators, clusters, services running in pods).
+
+## Base roles shared across tiers (Ansible)
+- GPU driver and CUDA stack installation.
+- Docker/Containerd runtime setup.
+- System parameter tuning (kernel limits, hugepages, network stack), plus user home/SSH layout.
+- Database initialization tasks (e.g., bootstrap PostgreSQL/ClickHouse on hosts) and rendering templated configs such as `ClickHouse/users.xml`.
+
+## Coverage by capability tier
+| Tier | Host-focused roles (Ansible) | Kubernetes services (Helm) |
+| --- | --- | --- |
+| Data warehouse | ClickHouse host bootstrap & config render; PostgreSQL init where needed. |  — |
+| Big data | JVM/runtime, local disks, and OS tuning for data nodes. | Spark Operator; Flink Operator; Kafka/Redpanda; MinIO. |
+| ML | GPU runtime base (drivers, container runtime), Python ML base image prep; user workspace/SSH. | Ray Cluster; MLflow; JupyterHub. |
+| DL | Same GPU/system tuning plus inference node bootstrap (tensorRT/cuDNN as needed). | Triton Inference Server; LMDeploy (for deployment runtimes). |
+| Large models | Secure SSH/user profiles and config templating for model storage/IO. | vLLM serving; model-specific Helm releases atop Ray/K8s. |
+
+## Suggested role layout under `/playbooks/roles/`
+- `common/` (new): shared tasks for system tuning, users/SSH, and package repos for GPU/runtime support.
+- `gpu/`: install GPU drivers + CUDA toolkit.
+- `container_runtime/`: install and configure Docker/Containerd with GPU runtime integration.
+- `database_init/`: bootstrap on-host databases (e.g., PostgreSQL, ClickHouse), render config files (`users.xml`, etc.).
+- `bigdata_node_prep/`: OS/disk tuning for Spark/Flink/Kafka/Redpanda/MinIO hosts.
+- `ml_node_prep/`: Python/conda base, SSH workspace prep for ML workloads.
+- `dl_inference_node/`: tensorRT/cuDNN dependencies and runtime checks for Triton/LMDeploy nodes.
+
+Helm-delivered components should live under `playbooks/roles/charts/` or the repo’s Helm release structure and include Spark/Flink Operators, Kafka/Redpanda/MinIO, Ray Cluster, Triton, vLLM/LMDeploy, MLflow, and JupyterHub.

--- a/playbooks/roles/charts/embedding-service/README.md
+++ b/playbooks/roles/charts/embedding-service/README.md
@@ -1,0 +1,3 @@
+# embedding-service (chart)
+
+Placeholder role for managing the Helm chart release of embedding-service.

--- a/playbooks/roles/charts/embedding-service/tasks/main.yml
+++ b/playbooks/roles/charts/embedding-service/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/feast/README.md
+++ b/playbooks/roles/charts/feast/README.md
@@ -1,0 +1,3 @@
+# feast (chart)
+
+Placeholder role for managing the Helm chart release of feast.

--- a/playbooks/roles/charts/feast/tasks/main.yml
+++ b/playbooks/roles/charts/feast/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/flink-operator/README.md
+++ b/playbooks/roles/charts/flink-operator/README.md
@@ -1,0 +1,3 @@
+# flink-operator (chart)
+
+Placeholder role for managing the Helm chart release of flink-operator.

--- a/playbooks/roles/charts/flink-operator/tasks/main.yml
+++ b/playbooks/roles/charts/flink-operator/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/grafana/README.md
+++ b/playbooks/roles/charts/grafana/README.md
@@ -1,0 +1,3 @@
+# grafana (chart)
+
+Placeholder role for managing the Helm chart release of grafana.

--- a/playbooks/roles/charts/grafana/tasks/main.yml
+++ b/playbooks/roles/charts/grafana/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/iceberg-bucket/README.md
+++ b/playbooks/roles/charts/iceberg-bucket/README.md
@@ -1,0 +1,3 @@
+# iceberg-bucket (chart)
+
+Placeholder role for managing the Helm chart release of iceberg-bucket.

--- a/playbooks/roles/charts/iceberg-bucket/tasks/main.yml
+++ b/playbooks/roles/charts/iceberg-bucket/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/inference-gateway/README.md
+++ b/playbooks/roles/charts/inference-gateway/README.md
@@ -1,0 +1,3 @@
+# inference-gateway (chart)
+
+Placeholder role for managing the Helm chart release of inference-gateway.

--- a/playbooks/roles/charts/inference-gateway/tasks/main.yml
+++ b/playbooks/roles/charts/inference-gateway/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/kafka-cluster/README.md
+++ b/playbooks/roles/charts/kafka-cluster/README.md
@@ -1,0 +1,3 @@
+# kafka-cluster (chart)
+
+Placeholder role for managing the Helm chart release of kafka-cluster.

--- a/playbooks/roles/charts/kafka-cluster/tasks/main.yml
+++ b/playbooks/roles/charts/kafka-cluster/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/loki/README.md
+++ b/playbooks/roles/charts/loki/README.md
@@ -1,0 +1,3 @@
+# loki (chart)
+
+Placeholder role for managing the Helm chart release of loki.

--- a/playbooks/roles/charts/loki/tasks/main.yml
+++ b/playbooks/roles/charts/loki/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/minio/README.md
+++ b/playbooks/roles/charts/minio/README.md
@@ -1,0 +1,3 @@
+# minio (chart)
+
+Placeholder role for managing the Helm chart release of minio.

--- a/playbooks/roles/charts/minio/tasks/main.yml
+++ b/playbooks/roles/charts/minio/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/mlflow/README.md
+++ b/playbooks/roles/charts/mlflow/README.md
@@ -1,0 +1,3 @@
+# mlflow (chart)
+
+Placeholder role for managing the Helm chart release of mlflow.

--- a/playbooks/roles/charts/mlflow/tasks/main.yml
+++ b/playbooks/roles/charts/mlflow/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/nvidia-operator/README.md
+++ b/playbooks/roles/charts/nvidia-operator/README.md
@@ -1,0 +1,3 @@
+# nvidia-operator (chart)
+
+Placeholder role for managing the Helm chart release of nvidia-operator.

--- a/playbooks/roles/charts/nvidia-operator/tasks/main.yml
+++ b/playbooks/roles/charts/nvidia-operator/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/openobserve/README.md
+++ b/playbooks/roles/charts/openobserve/README.md
@@ -1,0 +1,3 @@
+# openobserve (chart)
+
+Placeholder role for managing the Helm chart release of openobserve.

--- a/playbooks/roles/charts/openobserve/tasks/main.yml
+++ b/playbooks/roles/charts/openobserve/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/postgres/README.md
+++ b/playbooks/roles/charts/postgres/README.md
@@ -1,0 +1,3 @@
+# postgres (chart)
+
+Placeholder role for managing the Helm chart release of postgres.

--- a/playbooks/roles/charts/postgres/tasks/main.yml
+++ b/playbooks/roles/charts/postgres/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/prometheus-stack/README.md
+++ b/playbooks/roles/charts/prometheus-stack/README.md
@@ -1,0 +1,3 @@
+# prometheus-stack (chart)
+
+Placeholder role for managing the Helm chart release of prometheus-stack.

--- a/playbooks/roles/charts/prometheus-stack/tasks/main.yml
+++ b/playbooks/roles/charts/prometheus-stack/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/ray-cluster/README.md
+++ b/playbooks/roles/charts/ray-cluster/README.md
@@ -1,0 +1,3 @@
+# ray-cluster (chart)
+
+Placeholder role for managing the Helm chart release of ray-cluster.

--- a/playbooks/roles/charts/ray-cluster/tasks/main.yml
+++ b/playbooks/roles/charts/ray-cluster/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/redpanda/README.md
+++ b/playbooks/roles/charts/redpanda/README.md
@@ -1,0 +1,3 @@
+# redpanda (chart)
+
+Placeholder role for managing the Helm chart release of redpanda.

--- a/playbooks/roles/charts/redpanda/tasks/main.yml
+++ b/playbooks/roles/charts/redpanda/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/sglang/README.md
+++ b/playbooks/roles/charts/sglang/README.md
@@ -1,0 +1,3 @@
+# sglang (chart)
+
+Placeholder role for managing the Helm chart release of sglang.

--- a/playbooks/roles/charts/sglang/tasks/main.yml
+++ b/playbooks/roles/charts/sglang/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/spark-operator/README.md
+++ b/playbooks/roles/charts/spark-operator/README.md
@@ -1,0 +1,3 @@
+# spark-operator (chart)
+
+Placeholder role for managing the Helm chart release of spark-operator.

--- a/playbooks/roles/charts/spark-operator/tasks/main.yml
+++ b/playbooks/roles/charts/spark-operator/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/tempo/README.md
+++ b/playbooks/roles/charts/tempo/README.md
@@ -1,0 +1,3 @@
+# tempo (chart)
+
+Placeholder role for managing the Helm chart release of tempo.

--- a/playbooks/roles/charts/tempo/tasks/main.yml
+++ b/playbooks/roles/charts/tempo/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/trino/README.md
+++ b/playbooks/roles/charts/trino/README.md
@@ -1,0 +1,3 @@
+# trino (chart)
+
+Placeholder role for managing the Helm chart release of trino.

--- a/playbooks/roles/charts/trino/tasks/main.yml
+++ b/playbooks/roles/charts/trino/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/charts/vllm/README.md
+++ b/playbooks/roles/charts/vllm/README.md
@@ -1,0 +1,3 @@
+# vllm (chart)
+
+Placeholder role for managing the Helm chart release of vllm.

--- a/playbooks/roles/charts/vllm/tasks/main.yml
+++ b/playbooks/roles/charts/vllm/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement Helm release tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement Helm release tasks."

--- a/playbooks/roles/docker/clickhouse/README.md
+++ b/playbooks/roles/docker/clickhouse/README.md
@@ -1,0 +1,3 @@
+# clickhouse (docker)
+
+Placeholder role for docker-compose style deployment of clickhouse.

--- a/playbooks/roles/docker/clickhouse/tasks/main.yml
+++ b/playbooks/roles/docker/clickhouse/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/embedding-service/README.md
+++ b/playbooks/roles/docker/embedding-service/README.md
@@ -1,0 +1,3 @@
+# embedding-service (docker)
+
+Placeholder role for docker-compose style deployment of embedding-service.

--- a/playbooks/roles/docker/embedding-service/tasks/main.yml
+++ b/playbooks/roles/docker/embedding-service/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/grafana/README.md
+++ b/playbooks/roles/docker/grafana/README.md
@@ -1,0 +1,3 @@
+# grafana (docker)
+
+Placeholder role for docker-compose style deployment of grafana.

--- a/playbooks/roles/docker/grafana/tasks/main.yml
+++ b/playbooks/roles/docker/grafana/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/kafka/README.md
+++ b/playbooks/roles/docker/kafka/README.md
@@ -1,0 +1,3 @@
+# kafka (docker)
+
+Placeholder role for docker-compose style deployment of kafka.

--- a/playbooks/roles/docker/kafka/tasks/main.yml
+++ b/playbooks/roles/docker/kafka/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/loki/README.md
+++ b/playbooks/roles/docker/loki/README.md
@@ -1,0 +1,3 @@
+# loki (docker)
+
+Placeholder role for docker-compose style deployment of loki.

--- a/playbooks/roles/docker/loki/tasks/main.yml
+++ b/playbooks/roles/docker/loki/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/minio/README.md
+++ b/playbooks/roles/docker/minio/README.md
@@ -1,0 +1,3 @@
+# minio (docker)
+
+Placeholder role for docker-compose style deployment of minio.

--- a/playbooks/roles/docker/minio/tasks/main.yml
+++ b/playbooks/roles/docker/minio/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/mlflow/README.md
+++ b/playbooks/roles/docker/mlflow/README.md
@@ -1,0 +1,3 @@
+# mlflow (docker)
+
+Placeholder role for docker-compose style deployment of mlflow.

--- a/playbooks/roles/docker/mlflow/tasks/main.yml
+++ b/playbooks/roles/docker/mlflow/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/postgres/README.md
+++ b/playbooks/roles/docker/postgres/README.md
@@ -1,0 +1,3 @@
+# postgres (docker)
+
+Placeholder role for docker-compose style deployment of postgres.

--- a/playbooks/roles/docker/postgres/tasks/main.yml
+++ b/playbooks/roles/docker/postgres/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/ray/README.md
+++ b/playbooks/roles/docker/ray/README.md
@@ -1,0 +1,3 @@
+# ray (docker)
+
+Placeholder role for docker-compose style deployment of ray.

--- a/playbooks/roles/docker/ray/tasks/main.yml
+++ b/playbooks/roles/docker/ray/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/redpanda/README.md
+++ b/playbooks/roles/docker/redpanda/README.md
@@ -1,0 +1,3 @@
+# redpanda (docker)
+
+Placeholder role for docker-compose style deployment of redpanda.

--- a/playbooks/roles/docker/redpanda/tasks/main.yml
+++ b/playbooks/roles/docker/redpanda/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/sglang/README.md
+++ b/playbooks/roles/docker/sglang/README.md
@@ -1,0 +1,3 @@
+# sglang (docker)
+
+Placeholder role for docker-compose style deployment of sglang.

--- a/playbooks/roles/docker/sglang/tasks/main.yml
+++ b/playbooks/roles/docker/sglang/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/trino/README.md
+++ b/playbooks/roles/docker/trino/README.md
@@ -1,0 +1,3 @@
+# trino (docker)
+
+Placeholder role for docker-compose style deployment of trino.

--- a/playbooks/roles/docker/trino/tasks/main.yml
+++ b/playbooks/roles/docker/trino/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/vllm/README.md
+++ b/playbooks/roles/docker/vllm/README.md
@@ -1,0 +1,3 @@
+# vllm (docker)
+
+Placeholder role for docker-compose style deployment of vllm.

--- a/playbooks/roles/docker/vllm/tasks/main.yml
+++ b/playbooks/roles/docker/vllm/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."


### PR DESCRIPTION
## Summary
- add placeholder Ansible role directories for docker-based services
- add placeholder Ansible role directories for Helm/chart-managed services

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383d43732c833280692d5de52997b8)