### PR TITLE
Add optional package cleanup for Ubuntu hosts

### DIFF
--- a/playbooks/roles/vhosts/common/defaults/main.yml
+++ b/playbooks/roles/vhosts/common/defaults/main.yml
@@ -51,3 +51,15 @@ packages:
       - audit
       - uidmap
       - fuse-overlayfs
+
+packages_cleanup:
+  enabled: false
+  ubuntu:
+    purge: true
+    list:
+      - snapd
+      - resolvconf
+      - popularity-contest
+      - apport
+      - whoopsie
+      - modemmanager

--- a/playbooks/roles/vhosts/common/tasks/common_debian.yml
+++ b/playbooks/roles/vhosts/common/tasks/common_debian.yml
@@ -13,3 +13,9 @@
     package_manager: apt
   when: (packages.apt.enabled | default(false)) | bool
   tags: [pkgs, baseline]
+
+- name: Common(Debian) | cleanup optional packages
+  ansible.builtin.include_tasks: packages_cleanup.yml
+  when:
+    - (packages_cleanup.enabled | default(false)) | bool
+  tags: [pkgs, baseline, cleanup]

--- a/playbooks/roles/vhosts/common/tasks/packages.yml
+++ b/playbooks/roles/vhosts/common/tasks/packages.yml
@@ -15,6 +15,15 @@
     - normalized_base_dependencies | length > 0
   become: true
 
+# 确保仓库缓存更新后再安装主包
+- name: Refresh apt cache before package install
+  ansible.builtin.apt:
+    update_cache: true
+  when:
+    - package_manager == 'apt'
+    - normalized_package_list | length > 0
+  become: true
+
 # 实际安装
 - name: Install packages via apt
   ansible.builtin.apt:

--- a/playbooks/roles/vhosts/common/tasks/packages_cleanup.yml
+++ b/playbooks/roles/vhosts/common/tasks/packages_cleanup.yml
@@ -1,0 +1,16 @@
+---
+- name: Cleanup | normalize config
+  ansible.builtin.set_fact:
+    cleanup_config: "{{ packages_cleanup[ansible_facts.distribution | lower] | default({}) }}"
+  tags: [pkgs, baseline, cleanup]
+
+- name: Cleanup | remove optional packages
+  ansible.builtin.apt:
+    name: "{{ cleanup_config.list | default([]) }}"
+    state: absent
+    purge: "{{ cleanup_config.purge | default(true) }}"
+  when:
+    - ansible_facts.distribution == "Ubuntu"
+    - (cleanup_config.list | default([])) | length > 0
+  tags: [pkgs, baseline, cleanup]
+  become: true


### PR DESCRIPTION
## Summary
- add defaulted-off Ubuntu package cleanup list for optional removal of nonessential packages
- include cleanup task in Debian baseline flow with appropriate tags and purge support
- refresh apt cache before installing packages to avoid missing package errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e63ee289c8332a1b60d5a83c9a8b7)