### PR TITLE
Add retries when downloading Docker GPG key

### DIFF
--- a/playbooks/roles/vhosts/docker/tasks/main.yml
+++ b/playbooks/roles/vhosts/docker/tasks/main.yml
@@ -43,6 +43,10 @@
         url: https://download.docker.com/linux/ubuntu/gpg
         dest: /etc/apt/keyrings/docker.asc
         mode: '0644'
+      register: docker_gpg_download
+      until: docker_gpg_download is succeeded
+      retries: 5
+      delay: 3
 
     - name: Add Docker repository
       ansible.builtin.apt_repository:


### PR DESCRIPTION
## Summary
- add retry handling to the Docker GPG key download task to reduce transient failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6953aaf88332b4cd49b0c75eafaa)