### PR TITLE
Add bootstrap compose templates to observability roles

### DIFF
--- a/playbooks/deploy_OpenObserve_docker.yaml
+++ b/playbooks/deploy_OpenObserve_docker.yaml
@@ -1,0 +1,5 @@
+- name: setup OpenObserve
+  hosts: all
+  become: true
+  roles:
+    - docker/OpenObserve/

--- a/playbooks/deploy_Tempo_docker.yaml
+++ b/playbooks/deploy_Tempo_docker.yaml
@@ -1,0 +1,5 @@
+- name: setup Tempo
+  hosts: all
+  become: true
+  roles:
+    - docker/Tempo/

--- a/playbooks/deploy_VictoriaLogs_docker.yaml
+++ b/playbooks/deploy_VictoriaLogs_docker.yaml
@@ -1,0 +1,5 @@
+- name: setup VictoriaLogs
+  hosts: all
+  become: true
+  roles:
+    - docker/VictoriaLogs/

--- a/playbooks/deploy_VictoriaMetrics_docker.yaml
+++ b/playbooks/deploy_VictoriaMetrics_docker.yaml
@@ -1,0 +1,5 @@
+- name: setup VictoriaMetrics
+  hosts: all
+  become: true
+  roles:
+    - docker/VictoriaMetrics/

--- a/playbooks/deploy_otel_docker.yaml
+++ b/playbooks/deploy_otel_docker.yaml
@@ -1,0 +1,5 @@
+- name: setup otel
+  hosts: all
+  become: true
+  roles:
+    - docker/otel/

--- a/playbooks/roles/docker/OpenObserve/README.md
+++ b/playbooks/roles/docker/OpenObserve/README.md
@@ -1,0 +1,5 @@
+# OpenObserve (docker)
+
+Placeholder role for docker-compose style deployment of OpenObserve.
+
+Templates include docker-compose.yaml with bootstrap nginx and certbot services mirroring the Zitadel setup.

--- a/playbooks/roles/docker/OpenObserve/tasks/main.yml
+++ b/playbooks/roles/docker/OpenObserve/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/OpenObserve/templates/docker-compose.yaml
+++ b/playbooks/roles/docker/OpenObserve/templates/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  bootstrap-nginx:
+    profiles: ["bootstrap"]
+    image: nginx:mainline-alpine
+    container_name: bootstrap-nginx
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/nginx/nginx.conf:/etc/nginx/nginx.conf"
+      - "{{ zitadel_workspace }}/nginx/conf.d/bootstrap-nginx.conf:/etc/nginx/conf.d/bootstrap-nginx.conf"
+    ports:
+      - "80:80"       # 暂时只占用80
+    networks:
+      - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+  certbot:
+    profiles: ["bootstrap"]
+    image: certbot/certbot
+    container_name: certbot
+    command: >
+      certonly --webroot
+      --webroot-path=/var/www/certbot
+      --email manbuzhe2009@qq.com
+      --agree-tos
+      --no-eff-email
+      --keep-until-expiring
+      --non-interactive
+      -d {{ zitadel_domain }}
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+    networks:
+      - app
+
+networks:
+  app:

--- a/playbooks/roles/docker/Tempo/README.md
+++ b/playbooks/roles/docker/Tempo/README.md
@@ -1,0 +1,5 @@
+# Tempo (docker)
+
+Placeholder role for docker-compose style deployment of Tempo.
+
+Templates include docker-compose.yaml with bootstrap nginx and certbot services mirroring the Zitadel setup.

--- a/playbooks/roles/docker/Tempo/tasks/main.yml
+++ b/playbooks/roles/docker/Tempo/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/Tempo/templates/docker-compose.yaml
+++ b/playbooks/roles/docker/Tempo/templates/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  bootstrap-nginx:
+    profiles: ["bootstrap"]
+    image: nginx:mainline-alpine
+    container_name: bootstrap-nginx
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/nginx/nginx.conf:/etc/nginx/nginx.conf"
+      - "{{ zitadel_workspace }}/nginx/conf.d/bootstrap-nginx.conf:/etc/nginx/conf.d/bootstrap-nginx.conf"
+    ports:
+      - "80:80"       # 暂时只占用80
+    networks:
+      - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+  certbot:
+    profiles: ["bootstrap"]
+    image: certbot/certbot
+    container_name: certbot
+    command: >
+      certonly --webroot
+      --webroot-path=/var/www/certbot
+      --email manbuzhe2009@qq.com
+      --agree-tos
+      --no-eff-email
+      --keep-until-expiring
+      --non-interactive
+      -d {{ zitadel_domain }}
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+    networks:
+      - app
+
+networks:
+  app:

--- a/playbooks/roles/docker/VictoriaLogs/README.md
+++ b/playbooks/roles/docker/VictoriaLogs/README.md
@@ -1,0 +1,5 @@
+# VictoriaLogs (docker)
+
+Placeholder role for docker-compose style deployment of VictoriaLogs.
+
+Templates include docker-compose.yaml with bootstrap nginx and certbot services mirroring the Zitadel setup.

--- a/playbooks/roles/docker/VictoriaLogs/tasks/main.yml
+++ b/playbooks/roles/docker/VictoriaLogs/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/VictoriaLogs/templates/docker-compose.yaml
+++ b/playbooks/roles/docker/VictoriaLogs/templates/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  bootstrap-nginx:
+    profiles: ["bootstrap"]
+    image: nginx:mainline-alpine
+    container_name: bootstrap-nginx
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/nginx/nginx.conf:/etc/nginx/nginx.conf"
+      - "{{ zitadel_workspace }}/nginx/conf.d/bootstrap-nginx.conf:/etc/nginx/conf.d/bootstrap-nginx.conf"
+    ports:
+      - "80:80"       # 暂时只占用80
+    networks:
+      - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+  certbot:
+    profiles: ["bootstrap"]
+    image: certbot/certbot
+    container_name: certbot
+    command: >
+      certonly --webroot
+      --webroot-path=/var/www/certbot
+      --email manbuzhe2009@qq.com
+      --agree-tos
+      --no-eff-email
+      --keep-until-expiring
+      --non-interactive
+      -d {{ zitadel_domain }}
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+    networks:
+      - app
+
+networks:
+  app:

--- a/playbooks/roles/docker/VictoriaMetrics/README.md
+++ b/playbooks/roles/docker/VictoriaMetrics/README.md
@@ -1,0 +1,5 @@
+# VictoriaMetrics (docker)
+
+Placeholder role for docker-compose style deployment of VictoriaMetrics.
+
+Templates include docker-compose.yaml with bootstrap nginx and certbot services mirroring the Zitadel setup.

--- a/playbooks/roles/docker/VictoriaMetrics/tasks/main.yml
+++ b/playbooks/roles/docker/VictoriaMetrics/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/VictoriaMetrics/templates/docker-compose.yaml
+++ b/playbooks/roles/docker/VictoriaMetrics/templates/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  bootstrap-nginx:
+    profiles: ["bootstrap"]
+    image: nginx:mainline-alpine
+    container_name: bootstrap-nginx
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/nginx/nginx.conf:/etc/nginx/nginx.conf"
+      - "{{ zitadel_workspace }}/nginx/conf.d/bootstrap-nginx.conf:/etc/nginx/conf.d/bootstrap-nginx.conf"
+    ports:
+      - "80:80"       # 暂时只占用80
+    networks:
+      - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+  certbot:
+    profiles: ["bootstrap"]
+    image: certbot/certbot
+    container_name: certbot
+    command: >
+      certonly --webroot
+      --webroot-path=/var/www/certbot
+      --email manbuzhe2009@qq.com
+      --agree-tos
+      --no-eff-email
+      --keep-until-expiring
+      --non-interactive
+      -d {{ zitadel_domain }}
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+    networks:
+      - app
+
+networks:
+  app:

--- a/playbooks/roles/docker/otel/README.md
+++ b/playbooks/roles/docker/otel/README.md
@@ -1,0 +1,5 @@
+# otel (docker)
+
+Placeholder role for docker-compose style deployment of otel.
+
+Templates include docker-compose.yaml with bootstrap nginx and certbot services mirroring the Zitadel setup.

--- a/playbooks/roles/docker/otel/tasks/main.yml
+++ b/playbooks/roles/docker/otel/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# TODO: implement docker deployment tasks
+- name: Placeholder task
+  debug:
+    msg: "Role placeholder. Implement docker deployment tasks."

--- a/playbooks/roles/docker/otel/templates/docker-compose.yaml
+++ b/playbooks/roles/docker/otel/templates/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  bootstrap-nginx:
+    profiles: ["bootstrap"]
+    image: nginx:mainline-alpine
+    container_name: bootstrap-nginx
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/nginx/nginx.conf:/etc/nginx/nginx.conf"
+      - "{{ zitadel_workspace }}/nginx/conf.d/bootstrap-nginx.conf:/etc/nginx/conf.d/bootstrap-nginx.conf"
+    ports:
+      - "80:80"       # 暂时只占用80
+    networks:
+      - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+  certbot:
+    profiles: ["bootstrap"]
+    image: certbot/certbot
+    container_name: certbot
+    command: >
+      certonly --webroot
+      --webroot-path=/var/www/certbot
+      --email manbuzhe2009@qq.com
+      --agree-tos
+      --no-eff-email
+      --keep-until-expiring
+      --non-interactive
+      -d {{ zitadel_domain }}
+    volumes:
+      - "{{ zitadel_workspace }}/certbot/conf:/etc/letsencrypt"
+      - "{{ zitadel_workspace }}/certbot/www:/var/www/certbot"
+    networks:
+      - app
+
+networks:
+  app:


### PR DESCRIPTION
## Summary
- add docker-compose templates for VictoriaMetrics, VictoriaLogs, OpenObserve, Tempo, and otel roles including bootstrap nginx and certbot services
- update each role README to note the new bootstrap-enabled docker-compose template

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694013585c2c833285af1cd6f0ec7de8)