### PR TITLE
Add Docker Grafana role and deployment playbook

### DIFF
--- a/playbooks/deploy_grafana_docker.yaml
+++ b/playbooks/deploy_grafana_docker.yaml
@@ -1,0 +1,11 @@
+- name: setup grafana (docker)
+  hosts: all
+  become: true
+  vars:
+    grafana_domain: "{{ domain }}"
+    grafana_workspace: /opt/grafana
+    grafana_admin_user: admin
+    grafana_admin_password: admin
+  roles:
+    - vhosts/docker/
+    - docker/grafana/

--- a/playbooks/roles/docker/grafana/README.md
+++ b/playbooks/roles/docker/grafana/README.md
@@ -1,3 +1,20 @@
-# grafana (docker)
+# Grafana (Docker)
 
-Placeholder role for docker-compose style deployment of grafana.
+This role deploys Grafana with Docker Compose, creating a persistent data directory and templating a simple `docker-compose.yaml` into `{{ grafana_workspace }}`.
+
+## Defaults
+- `grafana_workspace`: `/opt/grafana`
+- `grafana_image`: `grafana/grafana:10.4.6`
+- `grafana_domain`: `grafana.svc.plus`
+- `grafana_protocol`: `http`
+- `grafana_host_port`: `3000`
+- `grafana_admin_user`: `admin`
+- `grafana_admin_password`: `admin`
+
+## Run
+
+Example playbook execution:
+
+```bash
+ansible-playbook -i inventory.ini playbooks/deploy_grafana_docker.yaml -e "domain=grafana.example.com" -l grafana.example.com
+```

--- a/playbooks/roles/docker/grafana/defaults/main.yml
+++ b/playbooks/roles/docker/grafana/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Default settings for Grafana Docker deployment
+grafana_workspace: /opt/grafana
+grafana_image: grafana/grafana:10.4.6
+grafana_domain: grafana.svc.plus
+grafana_protocol: http
+grafana_host_port: 3000
+grafana_admin_user: admin
+grafana_admin_password: admin

--- a/playbooks/roles/docker/grafana/tasks/main.yml
+++ b/playbooks/roles/docker/grafana/tasks/main.yml
@@ -1,5 +1,33 @@
 ---
-# TODO: implement docker deployment tasks
-- name: Placeholder task
-  debug:
-    msg: "Role placeholder. Implement docker deployment tasks."
+- name: Ensure Grafana directories exist
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - "{{ grafana_workspace }}"
+    - "{{ grafana_workspace }}/data"
+    - "{{ grafana_workspace }}/provisioning"
+
+- name: Ensure Grafana data directory ownership
+  become: true
+  ansible.builtin.file:
+    path: "{{ grafana_workspace }}/data"
+    state: directory
+    owner: "472"
+    group: "472"
+    recurse: true
+
+- name: Template Grafana Docker Compose file
+  become: true
+  ansible.builtin.template:
+    src: docker-compose.yaml.j2
+    dest: "{{ grafana_workspace }}/docker-compose.yaml"
+    mode: "0644"
+
+- name: Launch Grafana with Docker Compose
+  become: true
+  ansible.builtin.command: docker compose -f {{ grafana_workspace }}/docker-compose.yaml up -d
+  args:
+    chdir: "{{ grafana_workspace }}"

--- a/playbooks/roles/docker/grafana/templates/docker-compose.yaml.j2
+++ b/playbooks/roles/docker/grafana/templates/docker-compose.yaml.j2
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  grafana:
+    image: "{{ grafana_image }}"
+    container_name: grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: "{{ grafana_admin_user }}"
+      GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_admin_password }}"
+      GF_SERVER_DOMAIN: "{{ grafana_domain }}"
+      GF_SERVER_ROOT_URL: "{{ grafana_protocol }}://{{ grafana_domain }}/"
+    ports:
+      - "{{ grafana_host_port }}:3000"
+    volumes:
+      - "{{ grafana_workspace }}/data:/var/lib/grafana"
+      - "{{ grafana_workspace }}/provisioning:/etc/grafana/provisioning"
+    user: "472:472"


### PR DESCRIPTION
## Summary
- implement Docker-based Grafana role with defaults, compose template, and documentation
- add deploy_grafana_docker playbook to invoke the Docker setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940139dcc1c8332bd2a2a073137be05)