### PR TITLE
docs: 确立权威仓库地位，并将 IaC 拓扑声明纳入 scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,91 @@
 # Cloud-Neutral Toolkit GitOps
 
-This repository is the GitOps declaration layer for the Cloud-Neutral Toolkit.
+This repository is the **authoritative** GitOps declaration layer for the Cloud-Neutral Toolkit.
+
+Consumers reference it by URL and ref rather than vendoring copies — for example the
+`setup-iac-env` composite action in `platform-ops-toolkit`, which takes `gitops_repo_name`
+and `gitops_repo_ref` as inputs. Declarations live here; the pipelines that act on them
+live in their own repositories and pin the ref they consume.
 
 ## Scope
 
-- Store declarative Kubernetes resources, Flux Kustomizations, and non-sensitive multi-environment values.
-- Keep application charts and Helm templates in the dedicated chart repository.
-- Keep imperative automation such as Ansible playbooks and inventories out of this repository.
+**In scope — declarative state:**
+
+- Kubernetes resources and Flux Kustomizations.
+- Non-sensitive multi-environment values.
+- **IaC topology declarations**: the desired set of hosts, their sizes, groups, and service
+  domains per environment. These are inputs consumed by Terraform renderers and by CMDB /
+  inventory generators.
+
+**Out of scope:**
+
+- Application charts and Helm templates — these belong in the dedicated chart repository.
+- Imperative automation: Ansible playbooks, roles, and hand-maintained inventories.
+- Secrets of any kind. Credentials are distributed at runtime through Vault, never committed
+  here. Topology declarations may contain SSH **public** keys; nothing private.
+
+### On topology declarations specifically
+
+A topology declaration states *what should exist* — it is data, not automation. That it is
+later rendered into Terraform HCL, or into an Ansible inventory, does not make it imperative
+automation, and does not conflict with the exclusion above. The line is:
+
+| | Belongs here | Belongs to the pipeline repo |
+|---|---|---|
+| Host list, plan, groups, service domains | ✅ declaration | |
+| The renderer that turns it into HCL | | ✅ |
+| The generated `cmdb.json` / `inventory.ini` | | ✅ (build artifact) |
+| Playbooks and roles that configure the hosts | | ✅ |
+
+Generated inventories remain out of scope. The *declaration they are generated from* is in
+scope.
 
 ## Layout
 
-- `infra/`: platform, infrastructure, and shared service declarations
-- `apps/`: application release declarations
-- `clusters/`: cluster-level overlays and entrypoints
+- `environments/`: cluster-level overlays and entrypoints (`clusters/<env>/`)
+- `services/`: per-service declarations shared across environments
+- `resources/`: IaC topology declarations, keyed `<project>/<env>/<provider>/`
+- `skills/`: repository-scoped conventions consumed by agents
 - `docs/`: repository conventions and operational documentation
 
-For a quick structure overview, see [docs/repo-structure.md](docs/repo-structure.md).
+For a directory-level overview, see [docs/repo-structure.md](docs/repo-structure.md).
+
+### `resources/` path convention
+
+```
+resources/<project>/<env>/<provider>/<declaration>.yaml
+```
+
+This shape accommodates the two conventions already in use:
+
+| Consumer | Path |
+|---|---|
+| Multi-cloud account/resource matrices | `resources/svc.plus/uat/aws/account/bootstrap.yaml` |
+| Vultr VPS topology per business domain | `resources/svc.plus/uat/vultr/web-saas.yaml` |
+
+`<project>` is the domain base or account grouping, `<env>` is `sit` / `uat` / `prod`, and
+`<provider>` is the cloud the declaration targets. Keeping the provider in the path is what
+lets one environment span more than one cloud without the filenames colliding.
+
+**Do not hardcode environment-varying values inside a declaration.** Domains, hostnames and
+plans are supplied by the consuming pipeline (e.g. `TARGET_DOMAIN_BASE`, `INSTANCE_PLAN_API`).
+A per-file fallback default is worse than none: divergent fallbacks render output that is
+valid, plausible, and wrong in only some files.
+
+## Consuming this repository
+
+Pin a ref. A consumer that tracks a moving branch inherits every change here at the moment it
+runs, which is rarely what a deployment wants:
+
+```yaml
+- uses: ./.github/actions/setup-iac-env
+  with:
+    gitops_repo_name: https://github.com/ai-workspace-infra/gitops.git
+    gitops_repo_ref: ${{ inputs.gitops_repo_ref || 'main' }}
+    gitops_target_path: gitops
+```
+
+**A missing declaration must fail the consuming step.** Reading a path that does not exist and
+continuing — logging a warning and exiting 0 — produces a run that is green while having
+configured nothing. Consumers are responsible for asserting that the declaration they expected
+was actually found.

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -1,12 +1,41 @@
 # Repository Structure
 
-This repository contains declarative GitOps assets only. Below is a short overview of the key directories.
+This repository contains declarative GitOps assets only. Below is an overview of the key
+directories.
 
 | Directory | Purpose |
 |-----------|---------|
-| `apps` | Flux HelmRelease and Kustomize files for applications. |
-| `clusters` | Kustomize overlays for different clusters referencing the `apps` definitions. |
-| `infra` | Platform and infrastructure declarations managed by Flux. |
-| `scripts` | Utility scripts that support validation or operational workflows. |
-| `config` | Non-sensitive configuration references and examples. |
-| `docs` | Additional documentation. |
+| `environments` | Cluster-level overlays and entrypoints, under `clusters/<env>/`. |
+| `services` | Per-service declarations shared across environments. |
+| `resources` | IaC topology declarations, keyed `<project>/<env>/<provider>/`. Consumed by Terraform renderers and CMDB/inventory generators. |
+| `skills` | Repository-scoped conventions consumed by agents. |
+| `docs` | Repository conventions and operational documentation. |
+
+## `resources/`
+
+```
+resources/<project>/<env>/<provider>/<declaration>.yaml
+```
+
+- `<project>` — domain base or account grouping, e.g. `svc.plus`
+- `<env>` — `sit` / `uat` / `prod`
+- `<provider>` — the cloud the declaration targets, e.g. `vultr`, `aws`
+
+Keeping the provider in the path lets a single environment span more than one cloud without
+filenames colliding.
+
+A declaration states the desired hosts, their plans, groups and service domains. It is data.
+The renderer that turns it into Terraform HCL, and the `cmdb.json` / `inventory.ini` generated
+from it, belong to the consuming pipeline repository — the generated inventory is a build
+artifact and is not committed here.
+
+Values that vary per environment are supplied by the consuming pipeline rather than written
+inline, and declarations carry no fallback defaults for them. See the scope notes in
+[../README.md](../README.md).
+
+## What does not live here
+
+- Application charts and Helm templates — see the dedicated chart repository.
+- Ansible playbooks, roles, and hand-maintained inventories.
+- Secrets. Credentials are distributed at runtime via Vault. SSH **public** keys inside a
+  topology declaration are fine; nothing private is committed.


### PR DESCRIPTION
两件事:声明本仓为**权威** GitOps 层;扩展 scope 以容纳 IaC 拓扑声明,让 `config/resources/**` 可以从模块仓搬入。

## scope 需要一条明确的界定

原措辞排除了 *"imperative automation such as Ansible playbooks and **inventories**"* —— 这读起来把拓扑声明也排除了,因为它最终会被渲染成 Terraform HCL 和 Ansible inventory。

**但它不该被排除**:声明陈述的是"应该存在什么",是数据;被渲染器消费不等于它是自动化。

新增一张表划清边界:

| | 属于本仓 | 属于流水线仓 |
|---|---|---|
| 主机清单、规格、分组、服务域名 | ✅ 声明 | |
| 把它渲染成 HCL 的渲染器 | | ✅ |
| 生成的 `cmdb.json` / `inventory.ini` | | ✅(构建产物) |
| 配置主机的 playbook / role | | ✅ |

**生成的 inventory 仍在 scope 之外;生成它所依据的声明进入 scope。**

## 两份文档描述的结构都不存在

README 写 `infra/` `apps/` `clusters/`;`docs/repo-structure.md` 还多写了 `scripts/` `config/`。**实际是 `environments/` `services/` `skills/` `docs/`。**

两份都已修正 —— 一份与实际不符的结构文档比没有更糟,因为它会被信任。

## `resources/` 路径约定

```
resources/<project>/<env>/<provider>/<declaration>.yaml
```

**provider 这一段是关键**,它让现存的两种约定共存:

| 消费者 | 路径 |
|---|---|
| 多云 account/resource 矩阵 | `resources/svc.plus/uat/aws/account/bootstrap.yaml` |
| Vultr VPS 按业务域 | `resources/svc.plus/uat/vultr/web-saas.yaml` |

没有它,一个环境跨两朵云时文件名会撞。

## 两条从 platform-ops-toolkit 实战中得来的消费规则

**钉住 ref**,不要跟随分支 —— 否则一次部署会继承几秒前刚落地的任意改动。

**声明缺失必须让消费方失败** —— 现有的 AWS config 加载器是 `print warning; sys.exit(0)`,于是**声明根本没找到的 run 照样报绿,而什么都没配置**。

另记录:声明不为随环境变化的值携带 fallback 默认值,与 [iac_modules#224](https://github.com/ai-workspace-infra/iac_modules/pull/224) 删除的 19 处矛盾 fallback 一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)