### PR TITLE
feat(compose): add the web-saas stack for Doco-CD

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,36 @@
+# `compose/` — Docker Compose 部署声明
+
+由 [Doco-CD](https://doco.cd) 消费。Doco-CD 跑在目标主机上，克隆本仓库、读取
+`<stack>/.doco-cd.yml`，然后执行 `docker compose`。
+
+这一层与 `environments/`、`services/` 平行而**不重叠**：那两个目录是
+Kubernetes + Flux 的声明，面向未来的 k3s/sealos 集群；`compose/` 面向当前
+在单机 VPS 上以 Docker Compose 运行的域。两条路径服务于同一批服务的不同
+运行形态，迁移完成前都需要保留。
+
+## 版本轴
+
+`.env.<env>` 就是版本记录：CD 把新的镜像 tag 写进去、提交、推送，Doco-CD
+拉到新 commit 即部署新版本。**git log 就是部署历史**，不需要另一套部署元数据。
+
+镜像 tag 的取值遵循
+[镜像 Tag 跨仓契约](https://github.com/ai-workspace-infra/platform-ops-toolkit/blob/main/docs/domains/IMAGE-TAG-CONTRACT.md)：
+SIT 用户定义 / UAT `latest` / PROD `v*`·`release-*`。
+
+## 两条铁律
+
+**一、机密不进本目录。** 仓库是公开的，且 Doco-CD 每次部署都是全新 clone。
+口令与 token 放在主机的 `/etc/xcontrol/<stack>/secrets.env`，由 Ansible 从
+Vault 渲染；compose 里用绝对路径 `env_file` 引用。
+
+**二、bind mount 一律写绝对路径。** 相对路径会解析到 Doco-CD 那个临时 clone
+目录里 —— 证书和配置并不在仓库里，于是挂载出一个空目录**而不是报错**。这是
+静默故障，不是启动失败。
+
+## 新增一个 stack
+
+1. 建 `compose/<stack>/`，放 `.doco-cd.yml` + `docker-compose.yml` + `.env.<env>`
+2. compose 里所有 bind mount 用绝对路径，机密走主机侧 `env_file`
+3. 镜像引用写 `${VAR:?...}` 形式 —— 变量缺失时必须让部署失败，而不是拉一个
+   名字为空的镜像
+4. 在 Doco-CD 的 `POLL_CONFIG` 或 webhook 触发方里登记这个 stack

--- a/compose/web-saas/.doco-cd.yml
+++ b/compose/web-saas/.doco-cd.yml
@@ -1,0 +1,18 @@
+name: web-saas
+version: doco.v1
+working_dir: compose/web-saas
+compose_files:
+  - docker-compose.yml
+
+# 镜像版本轴。CD 把新的 tag 写进 .env.<env> 后提交推送, Doco-CD 拉到新
+# commit 就部署新版本 —— git ref 就是版本记录, 不需要额外的部署元数据。
+env_files:
+  - .env.uat
+
+# 机密不在这里。Doco-CD 每次部署都是全新 clone, 仓库里放不了也不该放
+# 口令; compose 里各服务通过绝对路径 env_file 读取主机上由 Ansible+Vault
+# 渲染的 /etc/xcontrol/web-saas/secrets.env。
+
+force_image_pull: true
+remove_orphans: true
+timeout: 300

--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -1,0 +1,20 @@
+# web-saas UAT 镜像版本。这个文件就是 UAT 的版本轴 —— CD 改这里、提交、
+# 推送, Doco-CD 拉到新 commit 就部署新版本, git log 即部署历史。
+#
+# 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/web-saas/secrets.env,
+# 由 Ansible 从 Vault 渲染, 不进本仓库。
+#
+# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md, UAT 的
+# deploy_tag 恒为 latest; 要钉死某次构建就把对应条目换成 sha-<40 位>。
+
+ACCOUNTS_IMAGE=ghcr.io/x-evor/accounts:latest
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:latest
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:latest
+
+# 基础组件不随业务发布走 deploy_tag, 钉在验证过的版本上, 单独升级。
+POSTGRES_IMAGE=postgres:17
+STUNNEL_SERVER_IMAGE=ghcr.io/x-evor/stunnel-server:2330d36
+STUNNEL_CLIENT_IMAGE=ghcr.io/x-evor/stunnel-client:latest
+CADDY_IMAGE=caddy:2-alpine
+
+STUNNEL_ACCEPT_PORT=15432

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -1,0 +1,165 @@
+# web-saas 域的 Docker Compose 声明, 由 Doco-CD 从本仓库拉取部署。
+#
+# 所有 bind mount 都写绝对路径。Doco-CD 每次部署都把本仓库全新 clone 到一个
+# 临时目录再运行 docker compose, 相对路径会解析到那个 clone 里 —— 证书和
+# 配置并不在仓库里(也不该在), 相对路径会挂载出空目录而不是报错。
+#
+# 主机侧这些路径由 Ansible 从 Vault 渲染, 与本文件的镜像版本轴解耦:
+#   /etc/xcontrol/web-saas/secrets.env      口令与 token
+#   /etc/xcontrol/web-saas/config/          postgresql.conf / stunnel / account.yaml
+#   /etc/xcontrol/web-saas/certs/           stunnel TLS 证书
+#   /etc/xcontrol/web-saas/Caddyfile        反向代理站点定义
+
+services:
+  postgres:
+    image: ${POSTGRES_IMAGE:?set in .env.<env>}
+    container_name: web-saas-postgres
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - /etc/xcontrol/web-saas/config/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "PGPASSWORD=$${POSTGRES_PASSWORD} psql -qAt -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-postgres} -h 127.0.0.1 -c 'SELECT 1' | grep -qx 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - web_saas_network
+
+  stunnel-server:
+    image: ${STUNNEL_SERVER_IMAGE:?set in .env.<env>}
+    container_name: web-saas-stunnel-server
+    user: root
+    restart: unless-stopped
+    ports:
+      - "${STUNNEL_ACCEPT_PORT:-15432}:15432"
+    volumes:
+      - /etc/xcontrol/web-saas/config/stunnel-server.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/web-saas/certs/server-cert.pem:/etc/stunnel/certs/server-cert.pem:ro
+      - /etc/xcontrol/web-saas/certs/server-key.pem:/etc/stunnel/certs/server-key.pem:ro
+    networks:
+      - web_saas_network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  stunnel-client:
+    image: ${STUNNEL_CLIENT_IMAGE:?set in .env.<env>}
+    container_name: web-saas-stunnel-client
+    restart: unless-stopped
+    environment:
+      STUNNEL_SERVICE: "postgres"
+      STUNNEL_ACCEPT: "5432"
+      STUNNEL_CONNECT: "stunnel-server:15432"
+      STUNNEL_CRONTAB: ""
+    volumes:
+      - /etc/xcontrol/web-saas/config/stunnel-client.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/web-saas/certs/ca-cert.pem:/etc/stunnel/certs/ca-cert.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - web_saas_network
+    depends_on:
+      - stunnel-server
+
+  accounts:
+    image: ${ACCOUNTS_IMAGE:?set in .env.<env>}
+    container_name: web-saas-accounts
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    environment:
+      PORT: "18081"
+    volumes:
+      - /etc/xcontrol/web-saas/config/account.yaml:/etc/xcontrol/account.template.yaml:ro
+    networks:
+      - web_saas_network
+    depends_on:
+      stunnel-client:
+        condition: service_healthy
+
+  billing:
+    image: ${BILLING_IMAGE:?set in .env.<env>}
+    container_name: web-saas-billing
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    environment:
+      BILLING_SERVICE_LISTEN_ADDR: "0.0.0.0:8081"
+    networks:
+      - web_saas_network
+    depends_on:
+      stunnel-client:
+        condition: service_healthy
+
+  # console 镜像自带静态资源, 但 console 服务需要它们在一个共享卷里才能被
+  # Caddy 直接提供。这个一次性容器负责把资源刷进卷, 每次部署都重跑一遍,
+  # 否则换了镜像 tag 后静态资源还是上一版的。
+  console-assets:
+    image: ${CONSOLE_IMAGE:?set in .env.<env>}
+    container_name: web-saas-console-assets
+    restart: "no"
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        rm -rf /assets/_next /assets/chunks /assets/public
+        mkdir -p /assets /assets/public
+        cp -R /app/dashboard/static/. /assets/ || true
+        cp -R /app/dashboard/public/. /assets/public || true
+    volumes:
+      - console_static:/assets
+
+  console:
+    image: ${CONSOLE_IMAGE:?set in .env.<env>}
+    container_name: web-saas-console
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+    volumes:
+      - console_static:/app/dashboard/.next/static:ro
+    networks:
+      - web_saas_network
+    depends_on:
+      console-assets:
+        condition: service_completed_successfully
+
+  caddy:
+    image: ${CADDY_IMAGE:?set in .env.<env>}
+    container_name: web-saas-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/xcontrol/web-saas/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - web_saas_network
+    depends_on:
+      - accounts
+      - billing
+      - console
+
+networks:
+  web_saas_network:
+    name: docker_shared_network
+    driver: bridge
+
+volumes:
+  postgres_data:
+  console_static:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
`deploy_web_saas` 委派到的域 CD **没有任何东西可部署**：Doco-CD 已经由 bootstrap 步骤装在 UAT 主机上，但它的 `POLL_CONFIG` 是空的，也没有任何仓库声明过一个可供它拉取的 compose stack。这个 PR 就是那个 stack。

## 版本轴

`.env.<env>` 即版本记录：CD 写入新的镜像 tag → 提交 → 推送 → Doco-CD 拉到新 commit 就部署。**`git log` 就是部署历史**，不需要另一套部署元数据。

tag 取值遵循 [镜像 Tag 跨仓契约](https://github.com/ai-workspace-infra/platform-ops-toolkit/blob/main/docs/domains/IMAGE-TAG-CONTRACT.md)。

## 两条铁律，写进结构而不是写进文档

**机密不进仓库。** 本仓库公开，且 Doco-CD 每次部署都是全新 clone。口令与 token 放在主机 `/etc/xcontrol/web-saas/secrets.env`，由 Ansible 从 Vault 渲染，compose 里以绝对路径 `env_file` 引用。

**bind mount 一律绝对路径。** 相对路径会解析到 Doco-CD 那个临时 clone 里 —— 证书和配置并不在那儿，于是 docker **挂载出一个空目录而不是报错**。静默失败，正是这条交付链一直在对付的东西。

镜像引用写 `${VAR:?...}`，变量缺失时中止部署，而不是去拉一个名字为空的镜像。

## 来源

改编自 `playbooks` 仓里那个孤儿 compose 文件（`roles/vhosts/docker-compose/web-saas`）—— 它是 `942e523` refactor 的遗留物，从未真正跑通过：假设了 `./config`、`./certs` 这类相对路径，与任何真实主机布局都对不上。

## 验证

```
  resolved: ACCOUNTS_IMAGE BILLING_IMAGE CADDY_IMAGE CONSOLE_IMAGE
            POSTGRES_IMAGE STUNNEL_CLIENT_IMAGE STUNNEL_SERVER_IMAGE ...
  MISSING : none
  absolute bind mounts: 8, relative (must be 0): 0
```

## 尚未闭环（后续 PR）

1. 主机侧 `/etc/xcontrol/web-saas/{secrets.env,config/,certs/,Caddyfile}` 的 Ansible 渲染
2. Doco-CD 的 `POLL_CONFIG` / webhook 指向本仓库
3. `domain-cd.yaml` 改镜像 tag 并触发 webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)