### PR TITLE
fix(web-saas): point ACCOUNTS_IMAGE at the namespace CI publishes to

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -7,7 +7,7 @@
 # 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md, UAT 的
 # deploy_tag 恒为 latest; 要钉死某次构建就把对应条目换成 sha-<40 位>。
 
-ACCOUNTS_IMAGE=ghcr.io/x-evor/accounts:latest
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:latest
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:latest
 CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:latest
 


### PR DESCRIPTION
accounts 的 main 分支**首次构建成功**（run [30133564435](https://github.com/ai-workspace-services/accounts/actions/runs/30133564435)，在 [accounts#36](https://github.com/ai-workspace-services/accounts/pull/36) 的 CI-only 清理之后），实际推送的是：

```
ghcr.io/ai-workspace-services/accounts:latest
ghcr.io/ai-workspace-services/accounts:sha-ab9180ca...
```

但本文件写的是 `ghcr.io/x-evor/accounts`。

这解释了之前查 package 时的差异：**x-evor/accounts 返回 404（不存在），console 返回 403（存在但需鉴权）** —— 前者根本不是权限问题。即使 registry 凭据完全正确，Doco-CD 拉 accounts 仍会失败。

`BILLING_IMAGE` 与 `CONSOLE_IMAGE` 本来就指向 `ai-workspace-services`，未改动；那两个仓库各自的 CI 问题单独跟踪（见 platform-ops-toolkit `docs/tasks/2026-07-25-service-repo-ci-only-migration.md`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)