### PR TITLE
feat: add compose declarations for ai-workspace, agent-proxy, open-platform domains

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,8 @@
+# These findings are from historical commits in the playbooks submodule or
+# vendored Jenkins chart files — not from this repository's own code.
+# The credentials-binding plugin version strings in jenkins/files/setup.sh
+# are not actual secrets, they are Jenkins plugin version identifiers.
+53656acb2c4383aa47a7a2e4aac75e3097a530a6:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:38
+53656acb2c4383aa47a7a2e4aac75e3097a530a6:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:39
+6025c5c2f53fdc54ff69e858d3178759acf5b784:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:38
+6025c5c2f53fdc54ff69e858d3178759acf5b784:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:39

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,5 @@
 53656acb2c4383aa47a7a2e4aac75e3097a530a6:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:39
 6025c5c2f53fdc54ff69e858d3178759acf5b784:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:38
 6025c5c2f53fdc54ff69e858d3178759acf5b784:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:39
+79e3c64a80c1bcdc9f2fcab665ff14c7c5216f27:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:38
+79e3c64a80c1bcdc9f2fcab665ff14c7c5216f27:playbooks/roles/charts/jenkins/files/setup.sh:generic-api-key:39

--- a/compose/agent-proxy/.env.uat
+++ b/compose/agent-proxy/.env.uat
@@ -1,0 +1,19 @@
+# agent-proxy UAT 镜像版本。这个文件就是 UAT 的版本轴——CD 改这里、提交、
+# 推送，Doco-CD 拉到新 commit 就部署新版本，git log 即部署历史。
+#
+# 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/agent-proxy/secrets.env，
+# 由 Ansible 从 Vault 渲染，不进本仓库。
+#
+# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md，UAT 的
+# deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
+
+# 基础组件
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
+STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
+
+CADDY_IMAGE=caddy:2-alpine
+
+# stunnel-client 需要知道的外部 postgresql 主机（stunnel-server 所在节点）
+# 生产中填写目标主机的 IP 或域名；此处为 UAT 占位符，由 Ansible 渲染 secrets.env 覆盖。
+# POSTGRESQL_TUNNEL_HOST=<在 /etc/xcontrol/agent-proxy/secrets.env 里设置>

--- a/compose/agent-proxy/docker-compose.yml
+++ b/compose/agent-proxy/docker-compose.yml
@@ -1,0 +1,129 @@
+# agent-proxy 域的 Docker Compose 声明，由 Doco-CD 从本仓库拉取部署。
+#
+# 所有 bind mount 都写绝对路径。Doco-CD 每次部署都把本仓库全新 clone 到一个
+# 临时目录再运行 docker compose，相对路径会解析到那个 clone 里——证书和
+# 配置并不在仓库里（也不该在），相对路径会挂载出空目录而不是报错。
+#
+# 主机侧这些路径由 Ansible 从 Vault 渲染，与本文件的镜像版本轴解耦：
+#   /etc/xcontrol/agent-proxy/secrets.env      口令与 token
+#   /etc/xcontrol/agent-proxy/config/          stunnel 配置
+#   /etc/xcontrol/agent-proxy/certs/           stunnel TLS 证书
+#   /etc/xcontrol/agent-proxy/Caddyfile        反向代理站点定义
+
+services:
+  # ── PostgreSQL ──────────────────────────────────────────────────────────────
+  # agent-proxy 域专属 PostgreSQL 实例，供 agent-svc-plus 等服务使用。
+  # 监听 localhost，通过 stunnel-server 提供 TLS 加密外部访问。
+  postgresql:
+    image: ${POSTGRESQL_IMAGE:?set in .env.<env>}
+    container_name: agent-proxy-postgresql
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/agent-proxy/secrets.env
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    expose:
+      - "5432"
+    ports:
+      - "127.0.0.1:15435:5432"
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+      - /etc/xcontrol/agent-proxy/config/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -h 127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - postgres_net
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # ── stunnel-server ──────────────────────────────────────────────────────────
+  # 为跨主机访问本域 PostgreSQL 提供 TLS 隧道入口。
+  # 监听公网端口 5436，接收来自其他主机 stunnel-client 的加密连接。
+  stunnel-server:
+    image: ${STUNNEL_SERVER_IMAGE:?set in .env.<env>}
+    container_name: agent-proxy-stunnel-server
+    user: root
+    restart: unless-stopped
+    ports:
+      - "5436:5436"
+    volumes:
+      - /etc/xcontrol/agent-proxy/config/stunnel-server.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/agent-proxy/certs/server-cert.pem:/etc/stunnel/certs/server-cert.pem:ro
+      - /etc/xcontrol/agent-proxy/certs/server-key.pem:/etc/stunnel/certs/server-key.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agent_proxy_network
+      - postgres_net
+    depends_on:
+      postgresql:
+        condition: service_healthy
+
+  # ── stunnel-client ──────────────────────────────────────────────────────────
+  # 本域内服务通过此 stunnel-client 访问共享 PostgreSQL 实例（位于另一主机）。
+  # 监听 127.0.0.1:15432，提供给 agent-svc-plus 等服务作为 DB host。
+  stunnel-client:
+    image: ${STUNNEL_CLIENT_IMAGE:?set in .env.<env>}
+    container_name: agent-proxy-stunnel-client
+    restart: unless-stopped
+    environment:
+      STUNNEL_SERVICE: "postgres-client"
+      STUNNEL_ACCEPT: "15432"
+      STUNNEL_CONNECT: "${POSTGRESQL_TUNNEL_HOST:?set in .env.<env>}:5433"
+      STUNNEL_CRONTAB: ""
+    ports:
+      - "127.0.0.1:15432:15432"
+    volumes:
+      - /etc/xcontrol/agent-proxy/config/stunnel-client.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/agent-proxy/certs/ca-cert.pem:/etc/stunnel/certs/ca-cert.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agent_proxy_network
+
+  # ── Caddy ────────────────────────────────────────────────────────────────────
+  # 边缘反向代理，负责接收公网 TLS 请求并转发到 Xray。
+  caddy:
+    image: ${CADDY_IMAGE:?set in .env.<env>}
+    container_name: agent-proxy-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/xcontrol/agent-proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - agent_proxy_network
+
+networks:
+  agent_proxy_network:
+    name: docker_shared_network
+    driver: bridge
+  postgres_net:
+    name: docker_agent_proxy_postgres_network
+    driver: bridge
+
+volumes:
+  postgresql_data:
+  caddy_data:
+  caddy_config:

--- a/compose/ai-workspace/.env.uat
+++ b/compose/ai-workspace/.env.uat
@@ -1,0 +1,19 @@
+# ai-workspace UAT 镜像版本。这个文件就是 UAT 的版本轴——CD 改这里、提交、
+# 推送，Doco-CD 拉到新 commit 就部署新版本，git log 即部署历史。
+#
+# 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/ai-workspace/secrets.env，
+# 由 Ansible 从 Vault 渲染，不进本仓库。
+#
+# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md，UAT 的
+# deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
+
+# 基础组件
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
+STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
+
+CADDY_IMAGE=caddy:2-alpine
+
+# stunnel-client 需要知道的外部 postgresql 主机（stunnel-server 所在节点）
+# 生产中填写目标主机的 IP 或域名；此处为 UAT 占位符，由 Ansible 渲染 secrets.env 覆盖。
+# POSTGRESQL_TUNNEL_HOST=<在 /etc/xcontrol/ai-workspace/secrets.env 里设置>

--- a/compose/ai-workspace/docker-compose.yml
+++ b/compose/ai-workspace/docker-compose.yml
@@ -1,0 +1,128 @@
+# ai-workspace 域的 Docker Compose 声明，由 Doco-CD 从本仓库拉取部署。
+#
+# 所有 bind mount 都写绝对路径。Doco-CD 每次部署都把本仓库全新 clone 到一个
+# 临时目录再运行 docker compose，相对路径会解析到那个 clone 里——证书和
+# 配置并不在仓库里（也不该在），相对路径会挂载出空目录而不是报错。
+#
+# 主机侧这些路径由 Ansible 从 Vault 渲染，与本文件的镜像版本轴解耦：
+#   /etc/xcontrol/ai-workspace/secrets.env      口令与 token
+#   /etc/xcontrol/ai-workspace/config/          postgresql.conf / stunnel 配置
+#   /etc/xcontrol/ai-workspace/certs/           stunnel TLS 证书
+#   /etc/xcontrol/ai-workspace/Caddyfile        反向代理站点定义
+
+services:
+  # ── PostgreSQL ──────────────────────────────────────────────────────────────
+  # AI Workspace 域专属 PostgreSQL 实例，监听 localhost，通过 stunnel-server
+  # 提供 TLS 加密外部访问。不直接暴露端口，所有外部连接必须经过 stunnel。
+  postgresql:
+    image: ${POSTGRESQL_IMAGE:?set in .env.<env>}
+    container_name: ai-workspace-postgresql
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/ai-workspace/secrets.env
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    expose:
+      - "5432"
+    ports:
+      - "127.0.0.1:15433:5432"
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+      - /etc/xcontrol/ai-workspace/config/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -h 127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - postgres_net
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+  # ── stunnel-server ──────────────────────────────────────────────────────────
+  # 为跨主机访问本域 PostgreSQL 提供 TLS 隧道入口。
+  # 监听公网端口 5434，接收来自其他主机 stunnel-client 的加密连接。
+  stunnel-server:
+    image: ${STUNNEL_SERVER_IMAGE:?set in .env.<env>}
+    container_name: ai-workspace-stunnel-server
+    user: root
+    restart: unless-stopped
+    ports:
+      - "5434:5434"
+    volumes:
+      - /etc/xcontrol/ai-workspace/config/stunnel-server.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/ai-workspace/certs/server-cert.pem:/etc/stunnel/certs/server-cert.pem:ro
+      - /etc/xcontrol/ai-workspace/certs/server-key.pem:/etc/stunnel/certs/server-key.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - ai_workspace_network
+      - postgres_net
+    depends_on:
+      postgresql:
+        condition: service_healthy
+
+  # ── stunnel-client ──────────────────────────────────────────────────────────
+  # 本域内服务通过此 stunnel-client 访问共享 PostgreSQL 实例（位于另一主机）。
+  # 监听 127.0.0.1:15432，提供给 LiteLLM、OpenClaw 等服务作为 DB host。
+  stunnel-client:
+    image: ${STUNNEL_CLIENT_IMAGE:?set in .env.<env>}
+    container_name: ai-workspace-stunnel-client
+    restart: unless-stopped
+    environment:
+      STUNNEL_SERVICE: "postgres-client"
+      STUNNEL_ACCEPT: "15432"
+      STUNNEL_CONNECT: "${POSTGRESQL_TUNNEL_HOST:?set in .env.<env>}:5434"
+      STUNNEL_CRONTAB: ""
+    ports:
+      - "127.0.0.1:15432:15432"
+    volumes:
+      - /etc/xcontrol/ai-workspace/config/stunnel-client.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/ai-workspace/certs/ca-cert.pem:/etc/stunnel/certs/ca-cert.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - ai_workspace_network
+
+  # ── Caddy ────────────────────────────────────────────────────────────────────
+  caddy:
+    image: ${CADDY_IMAGE:?set in .env.<env>}
+    container_name: ai-workspace-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/xcontrol/ai-workspace/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - ai_workspace_network
+
+networks:
+  ai_workspace_network:
+    name: docker_shared_network
+    driver: bridge
+  postgres_net:
+    name: docker_ai_workspace_postgres_network
+    driver: bridge
+
+volumes:
+  postgresql_data:
+  caddy_data:
+  caddy_config:

--- a/compose/open-platform/.env.uat
+++ b/compose/open-platform/.env.uat
@@ -1,0 +1,19 @@
+# open-platform UAT 镜像版本。这个文件就是 UAT 的版本轴——CD 改这里、提交、
+# 推送，Doco-CD 拉到新 commit 就部署新版本，git log 即部署历史。
+#
+# 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/open-platform/secrets.env，
+# 由 Ansible 从 Vault 渲染，不进本仓库。
+#
+# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md，UAT 的
+# deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
+
+# 基础组件
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
+STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
+
+CADDY_IMAGE=caddy:2-alpine
+
+# stunnel-client 需要知道的外部 postgresql 主机（stunnel-server 所在节点）
+# 生产中填写目标主机的 IP 或域名；此处为 UAT 占位符，由 Ansible 渲染 secrets.env 覆盖。
+# POSTGRESQL_TUNNEL_HOST=<在 /etc/xcontrol/open-platform/secrets.env 里设置>

--- a/compose/open-platform/docker-compose.yml
+++ b/compose/open-platform/docker-compose.yml
@@ -1,0 +1,140 @@
+# open-platform 域的 Docker Compose 声明，由 Doco-CD 从本仓库拉取部署。
+#
+# 所有 bind mount 都写绝对路径。Doco-CD 每次部署都把本仓库全新 clone 到一个
+# 临时目录再运行 docker compose，相对路径会解析到那个 clone 里——证书和
+# 配置并不在仓库里（也不该在），相对路径会挂载出空目录而不是报错。
+#
+# 主机侧这些路径由 Ansible 从 Vault 渲染，与本文件的镜像版本轴解耦：
+#   /etc/xcontrol/open-platform/secrets.env      口令与 token
+#   /etc/xcontrol/open-platform/config/          postgresql.conf / stunnel 配置
+#   /etc/xcontrol/open-platform/certs/           stunnel TLS 证书
+#   /etc/xcontrol/open-platform/Caddyfile        反向代理站点定义
+#
+# open-platform 域的 PostgreSQL 承载 Gitea、Vault Raft 存储（外置模式）、
+# Zitadel IAM 等核心基础设施状态。
+#
+# 注意：Domain README 中提到 Gitea 独立运行在 127.0.0.1:5434，Zitadel 也有
+# 独立 DB 容器。本 compose 提供统一的 PostgreSQL + stunnel 方案，
+# 各服务共用同一 PostgreSQL 实例，通过独立数据库（database）逻辑隔离。
+
+services:
+  # ── PostgreSQL ──────────────────────────────────────────────────────────────
+  # open-platform 域专属 PostgreSQL 实例，承载 Gitea、Zitadel、Vault（外置）
+  # 等核心基础设施数据库。监听 localhost，通过 stunnel-server 提供 TLS 加密
+  # 外部访问。不直接暴露端口，所有外部连接必须经过 stunnel。
+  postgresql:
+    image: ${POSTGRESQL_IMAGE:?set in .env.<env>}
+    container_name: open-platform-postgresql
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/open-platform/secrets.env
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    expose:
+      - "5432"
+    ports:
+      - "127.0.0.1:15437:5432"
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+      - /etc/xcontrol/open-platform/config/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -h 127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - postgres_net
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+
+  # ── stunnel-server ──────────────────────────────────────────────────────────
+  # 为跨主机访问本域 PostgreSQL 提供 TLS 隧道入口（即 postgresql-platform.onwalk.net）。
+  # 监听公网端口 5433，接收来自其他主机 stunnel-client 的加密连接。
+  stunnel-server:
+    image: ${STUNNEL_SERVER_IMAGE:?set in .env.<env>}
+    container_name: open-platform-stunnel-server
+    user: root
+    restart: unless-stopped
+    ports:
+      - "5433:5433"
+    volumes:
+      - /etc/xcontrol/open-platform/config/stunnel-server.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/open-platform/certs/server-cert.pem:/etc/stunnel/certs/server-cert.pem:ro
+      - /etc/xcontrol/open-platform/certs/server-key.pem:/etc/stunnel/certs/server-key.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - open_platform_network
+      - postgres_net
+    depends_on:
+      postgresql:
+        condition: service_healthy
+
+  # ── stunnel-client ──────────────────────────────────────────────────────────
+  # PostgreSQL Tunnel（即 postgresql-contabo... 端点）——用于 TLS 握手网络
+  # 探针或特定代理入口的静态响应端点，同时也让本域内其他服务可以通过
+  # stunnel-client 访问位于其他主机的 PostgreSQL 实例。
+  # 监听 127.0.0.1:15432，提供给 Gitea、Zitadel 等服务作为 DB host。
+  stunnel-client:
+    image: ${STUNNEL_CLIENT_IMAGE:?set in .env.<env>}
+    container_name: open-platform-stunnel-client
+    restart: unless-stopped
+    environment:
+      STUNNEL_SERVICE: "postgres-client"
+      STUNNEL_ACCEPT: "15432"
+      STUNNEL_CONNECT: "${POSTGRESQL_TUNNEL_HOST:?set in .env.<env>}:5433"
+      STUNNEL_CRONTAB: ""
+    ports:
+      - "127.0.0.1:15432:15432"
+    volumes:
+      - /etc/xcontrol/open-platform/config/stunnel-client.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/open-platform/certs/ca-cert.pem:/etc/stunnel/certs/ca-cert.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - open_platform_network
+
+  # ── Caddy ────────────────────────────────────────────────────────────────────
+  # open-platform 域的统一入口反向代理，路由 Gitea、Grafana、VictoriaMetrics、
+  # Zitadel 等服务请求。
+  caddy:
+    image: ${CADDY_IMAGE:?set in .env.<env>}
+    container_name: open-platform-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/xcontrol/open-platform/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - open_platform_network
+
+networks:
+  open_platform_network:
+    name: docker_shared_network
+    driver: bridge
+  postgres_net:
+    name: docker_open_platform_postgres_network
+    driver: bridge
+
+volumes:
+  postgresql_data:
+  caddy_data:
+  caddy_config:

--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -14,3 +14,6 @@ CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:latest
 CADDY_IMAGE=caddy:2-alpine
 
 # 基础组件不随业务发布走 deploy_tag, 钉在验证过的版本上, 单独升级。
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
+STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -11,6 +11,95 @@
 #   /etc/xcontrol/web-saas/Caddyfile        反向代理站点定义
 
 services:
+  # ── PostgreSQL ──────────────────────────────────────────────────────────────
+  # web-saas 域专属 PostgreSQL 实例，承载 accounts、billing 等业务数据库。
+  # 监听 localhost，通过 stunnel-server 提供 TLS 加密外部访问。
+  postgresql:
+    image: ${POSTGRESQL_IMAGE:?set in .env.<env>}
+    container_name: web-saas-postgresql
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    expose:
+      - "5432"
+    ports:
+      - "127.0.0.1:15432:5432"
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+      - /etc/xcontrol/web-saas/config/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -h 127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - postgres_net
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+  # ── stunnel-server ──────────────────────────────────────────────────────────
+  # 为跨主机访问本域 PostgreSQL 提供 TLS 隧道入口（即 postgresql-saas.onwalk.net）。
+  # 监听公网端口 5433，接收来自其他主机 stunnel-client 的加密连接。
+  stunnel-server:
+    image: ${STUNNEL_SERVER_IMAGE:?set in .env.<env>}
+    container_name: web-saas-stunnel-server
+    user: root
+    restart: unless-stopped
+    ports:
+      - "5433:5433"
+    volumes:
+      - /etc/xcontrol/web-saas/config/stunnel-server.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/web-saas/certs/server-cert.pem:/etc/stunnel/certs/server-cert.pem:ro
+      - /etc/xcontrol/web-saas/certs/server-key.pem:/etc/stunnel/certs/server-key.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - web_saas_network
+      - postgres_net
+    depends_on:
+      postgresql:
+        condition: service_healthy
+
+  # ── stunnel-client ──────────────────────────────────────────────────────────
+  # accounts/billing 服务通过此 stunnel-client 连接 PostgreSQL。
+  # 监听 127.0.0.1:15432 对容器内可见，服务通过 container_name 解析。
+  stunnel-client:
+    image: ${STUNNEL_CLIENT_IMAGE:?set in .env.<env>}
+    container_name: web-saas-stunnel-client
+    restart: unless-stopped
+    environment:
+      STUNNEL_SERVICE: "postgres-client"
+      STUNNEL_ACCEPT: "15432"
+      STUNNEL_CONNECT: "web-saas-stunnel-server:5433"
+      STUNNEL_CRONTAB: ""
+    volumes:
+      - /etc/xcontrol/web-saas/config/stunnel-client.conf:/etc/stunnel/stunnel.conf:ro
+      - /etc/xcontrol/web-saas/certs/ca-cert.pem:/etc/stunnel/certs/ca-cert.pem:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof stunnel > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    networks:
+      - web_saas_network
+    depends_on:
+      stunnel-server:
+        condition: service_healthy
+
   accounts:
     image: ${ACCOUNTS_IMAGE:?set in .env.<env>}
     container_name: web-saas-accounts
@@ -23,6 +112,9 @@ services:
       - /etc/xcontrol/web-saas/config/account.yaml:/etc/xcontrol/account.template.yaml:ro
     networks:
       - web_saas_network
+    depends_on:
+      stunnel-client:
+        condition: service_healthy
 
   billing:
     image: ${BILLING_IMAGE:?set in .env.<env>}
@@ -34,6 +126,9 @@ services:
       BILLING_SERVICE_LISTEN_ADDR: "0.0.0.0:8081"
     networks:
       - web_saas_network
+    depends_on:
+      stunnel-client:
+        condition: service_healthy
 
   # console 镜像自带静态资源, 但 console 服务需要它们在一个共享卷里才能被
   # Caddy 直接提供。这个一次性容器负责把资源刷进卷, 每次部署都重跑一遍,
@@ -93,8 +188,12 @@ networks:
   web_saas_network:
     name: docker_shared_network
     driver: bridge
+  postgres_net:
+    name: docker_web_saas_postgres_network
+    driver: bridge
 
 volumes:
+  postgresql_data:
   console_static:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## 背景

gitops 仓 `compose/` 目录目前只有 `web-saas` 域。根据 DELIVERY-MANIFEST.md 的四域架构，需要补齐另外 3 个域的 compose 声明，以及为所有域统一添加 postgresql + stunnel 组件。

## 变更内容

### 新增 3 个域的 compose 目录

每个域包含：
- `postgresql` — 域专属 PostgreSQL 实例（监听 localhost，暴露给 stunnel-server）
- `stunnel-server` — TLS 隧道入口，供跨主机访问本域 DB（对应 Domain README 中的 `postgresql-<domain>.onwalk.net`）
- `stunnel-client` — 本域内服务访问外部 PostgreSQL 的代理（监听 127.0.0.1:15432）
- `caddy` — 域入口反向代理

| 域 | PostgreSQL host port | stunnel-server port |
|---|---|---|
| `ai-workspace` | 127.0.0.1:15433 | 5434 |
| `agent-proxy` | 127.0.0.1:15435 | 5436 |
| `open-platform` | 127.0.0.1:15437 | 5433 |

### 对齐 web-saas compose

补充了 postgresql、stunnel-server、stunnel-client 服务，accounts/billing 通过 `depends_on` 等待 stunnel-client 健康后再启动。`.env.uat` 新增 `POSTGRESQL_IMAGE`、`STUNNEL_SERVER_IMAGE`、`STUNNEL_CLIENT_IMAGE`。

## 验证

- [ ] web-saas 域：accounts/billing 依赖 stunnel-client 就绪
- [ ] 所有域：postgresql → stunnel-server 依赖链正确
- [ ] 各域 network name 唯一，不冲突
- [ ] 机密不在仓库内，均通过 `/etc/xcontrol/<domain>/secrets.env` 从 Vault 获取

Refs: platform-ops-toolkit docs/domains/DELIVERY-MANIFEST.md