### PR TITLE
fix(web-saas): inject RUNTIME_ENV into console at deploy time

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -14,3 +14,6 @@ CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:latest
 CADDY_IMAGE=caddy:2-alpine
 
 # 基础组件不随业务发布走 deploy_tag, 钉在验证过的版本上, 单独升级。
+
+# 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
+DEPLOY_ENV=uat

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -63,6 +63,11 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
+      # console 镜像不再自带 RUNTIME_ENV —— 它曾经在 Dockerfile 里被写死成
+      # prod, 于是任何来源的镜像启动即以生产身份运行、连生产认证服务。
+      # 环境是部署时的事实, 由这里注入; 不传时应用会落到它自己的安全默认值
+      # (dev), 而不是 prod。
+      RUNTIME_ENV: ${DEPLOY_ENV:?set in .env.<env>}
     volumes:
       - console_static:/app/dashboard/.next/static:ro
     networks:


### PR DESCRIPTION
console 镜像原先在 Dockerfile 里写死 `RUNTIME_ENV=prod`，而 `runtime-loader` 解析环境的**第一级**就是 `process.env.RUNTIME_ENV` —— 于是不论哪个分支构建出来的镜像，启动即以生产身份运行、对生产认证服务发请求。

**而且是静默的**：没有任何地方会记录"一个 UAT 容器认为自己是 prod"。

[portal 侧](https://github.com/ai-workspace-services/portal/pull/114) 已把它从镜像里移除 —— **环境是部署时的事实，不是构建时的属性**，同一个 digest 必须能部署到任意环境。所以改由本文件注入，取自 `DEPLOY_ENV`，避免与整个栈的部署环境脱节。

万一漏传，应用会落到 `dev` 而不是 `prod`：猜错成 dev 只是连不上，猜错成 prod 会把测试流量打进生产。

## 验证

用真实 `.env.uat` 对 `docker-compose.yml` 做插值解析：

```
console.environment: {'NODE_ENV': 'production', 'PORT': '3000', 'RUNTIME_ENV': 'uat'}
services: ['accounts', 'billing', 'caddy', 'console', 'console-assets']
```

无缺失的必需变量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)