### PR TITLE
fix(web-saas): declare the shared network external

### DIFF
--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -95,9 +95,24 @@ services:
       - console
 
 networks:
+  # external: true —— 这个网络的生命周期由 Ansible(web_saas_host_config
+  # 角色)管理, 在 compose 第一次 up 之前就已经存在, 且要跨多个域共享。
+  #
+  # 不加 external 时, Doco-CD 每次轮询部署都报:
+  #   network docker_shared_network was found but has incorrect label
+  #   com.docker.compose.network set to "" (expected: "web_saas_network")
+  # 因为 compose 期望自己创建的网络带着标准标签
+  # (com.docker.compose.network=web_saas_network), 而 Ansible 用裸
+  # `docker network create` 建的网络没有任何 compose 标签。compose 拒绝
+  # "接管"一个它不认识是自己创建的网络 —— 这不是权限问题, 是 compose
+  # 故意的安全检查, 防止悄悄劫持别的项目在用的网络。
+  #
+  # 结果是 Doco-CD 陷入每 60s 重试一次的失败循环: doco-cd 容器本身
+  # healthy, 但 web-saas 的四个服务从未启动 —— 从 docker ps 完全看不出来,
+  # 必须看 doco-cd 自己的日志。
   web_saas_network:
     name: docker_shared_network
-    driver: bridge
+    external: true
 
 volumes:
   console_static:


### PR DESCRIPTION
Doco-CD 自上次部署起每 60 秒失败一次：

\`\`\`
network docker_shared_network was found but has incorrect label
com.docker.compose.network set to "" (expected: "web_saas_network")
\`\`\`

## 根因

这个网络的生命周期是 Ansible（\`web_saas_host_config\` 角色）的，在 compose 第一次运行前用裸 \`docker network create\` 建好，且跨多个不完全属于这个 compose project 的服务共享。

compose 对任何没声明 \`external\` 的网络，默认认为自己拥有它，会检查自己的标签，发现不是自己创建的就拒绝接管——**这不是 bug，是故意的安全检查**，防止 compose 悄悄接管别的项目在用的网络。

## 修复

\`external: true\`。

## 验证

本地跑不了真实路径（\`/etc/xcontrol/web-saas\` 需要 root），改用一份指向假配置目录的临时 compose 文件测试：

- **加了 \`external: true\`**：\`up --no-start\` 直接进入拉镜像阶段，完全没有网络相关的报错
- **不加**：在一个裸建的网络上精确复现了报告的那条错误

## 为什么这次 run 报绿却实际没部署

\`run 30181885920\`（[platform-ops-toolkit](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30181885920)）全程报 success，包括 DNS 切换。但 \`doco-cd\` 容器本身全程 healthy——**docker ps 完全看不出问题**，因为 web-saas 那四个服务从未被 compose 尝试到"启动失败"这一步，是在网络检查这一关就被拒绝了。只有 \`doco-cd\` 自己的日志能看到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)