### PR TITLE
fix(compose): retire x-evor image paths across all four domains; flag services/ as deprecated

### DIFF
--- a/compose/agent-proxy/.env.uat
+++ b/compose/agent-proxy/.env.uat
@@ -8,7 +8,7 @@
 # deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
 
 # 基础组件
-POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
 STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
 STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
 

--- a/compose/ai-workspace/.env.uat
+++ b/compose/ai-workspace/.env.uat
@@ -8,7 +8,7 @@
 # deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
 
 # 基础组件
-POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
 STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
 STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
 

--- a/compose/open-platform/.env.uat
+++ b/compose/open-platform/.env.uat
@@ -8,7 +8,7 @@
 # deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
 
 # 基础组件
-POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql.svc.plus:latest
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
 STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
 STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
 

--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -15,12 +15,13 @@ CADDY_IMAGE=caddy:2-alpine
 
 # 基础组件不随业务发布走 deploy_tag, 钉在验证过的版本上, 单独升级。
 # 这三个镜像由 ai-workspace-infra/postgresql.svc.plus 的 ci-pipeline.yml
-# 构建, 推到 ghcr.io/x-evor/images/* —— 仓库名与镜像路径不一致, 照着仓库名
-# 拼地址会得到一个 404 的镜像。已在主机上用 docker manifest inspect 逐个
-# 确认这三个 tag 真实存在。
-POSTGRESQL_IMAGE=ghcr.io/x-evor/images/postgresql:latest
-STUNNEL_SERVER_IMAGE=ghcr.io/x-evor/images/stunnel-server:latest
-STUNNEL_CLIENT_IMAGE=ghcr.io/x-evor/images/stunnel-client:latest
+# 构建。历史上曾硬编码推到 ghcr.io/x-evor/images/*(该仓库改名/迁移到
+# ai-workspace-infra 之前留下的旧路径), 已在 CI 侧退休
+# (postgresql.svc.plus#19)、下面这三行同步改为当前实际发布路径。
+# 已在主机上用 docker manifest inspect 逐个确认这三个 tag 真实存在。
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
+STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:latest
 
 # 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
 DEPLOY_ENV=uat

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,46 @@
+# `services/` —— K8s/Flux 声明(未来路线,当前非活跃)
+
+这个目录是 Helm release + `OCIRepository` 形式的 K8s/Flux 部署声明，覆盖
+accounts / console / database(postgresql / stunnel-server / stunnel-client)
+/ observability 等域。
+
+**当前实际部署路径是 `compose/` 目录 + Doco-CD**（见仓库根 `compose/README.md`
+与 `compose/web-saas/`）。本目录代表的是 K8s/Flux 化的未来路线，与
+`compose/` 不并行运行——不要假设这里的清单已经在任何环境里生效。
+
+## ⚠️ 已知过期：`x-evor` 命名空间
+
+以下文件引用 `ghcr.io/x-evor/*`，这是相关仓库改名/迁移到当前 org
+（`ai-workspace-infra` / `ai-workspace-services`）之前留下的旧命名空间，
+**已在镜像构建方那一侧退休**（`ai-workspace-infra/postgresql.svc.plus#19`；
+`compose/*/.env.uat` 已同步更新）：
+
+```
+services/database/postgresql/oci-repository.yaml
+services/database/postgresql/stunnel-server-deployment.yaml
+services/database/postgresql/stunnel-client-deployment.yaml
+services/database/postgresql/values.yaml
+services/database/postgresql-core/oci-repository.yaml
+services/database/postgresql-core/values.yaml
+services/database/stunnel-server/stunnel-server-deployment.yaml
+services/observability/observability-stack/oci-repository.yaml
+services/stunnel-client/base/stunnel-client-deployment.yaml
+services/accounts/base/oci-repository.yaml
+services/accounts/base/values.yaml
+services/console/base/values.yaml
+services/console/base/oci-repository.yaml
+```
+
+**在启用这条 K8s/Flux 路线之前，必须逐个核对每个文件该指向哪个 org**——
+不能整批替换成同一个命名空间。已核实的对照（`docker manifest inspect`，
+非推断）：
+
+| 服务 | 正确路径 |
+|---|---|
+| postgresql / stunnel-server / stunnel-client | `ghcr.io/ai-workspace-infra/*`（不带 `images/` 前缀） |
+| accounts / console | `ghcr.io/ai-workspace-services/*`（不同 org，与上面的不是同一个） |
+| observability-stack | 未核实——启用前需要先确认 |
+
+混用会重演 web-saas compose 栈踩过的坑：地址写错时 Helm/Flux 侧不报任何
+错，镜像拉取会静默失败，且失败只出现在 Flux/kubelet 自己的事件日志里，
+不会体现在这份 YAML 或任何 CI 状态上。


### PR DESCRIPTION
配套 [postgresql.svc.plus#19](https://github.com/ai-workspace-infra/postgresql.svc.plus/pull/19)（构建侧退休 \`x-evor\` 命名空间）。

## compose 侧

四个域的 \`.env.uat\` 全部同步到正确路径（\`ghcr.io/ai-workspace-infra/*\`，不带 \`images/\` 前缀）。\`ai-workspace\`/\`agent-proxy\`/\`open-platform\` 这三份**从一开始就没对过**——#114 引入时写的是 \`ghcr.io/ai-workspace-infra/postgresql.svc.plus\`，同样是个不存在的路径。

## `services/` 目录：新增 README，标记为废弃/未激活

这是一整套并行的 K8s/Flux 声明（Helm release + \`OCIRepository\`），覆盖 accounts/console/database/observability——**不是当前活跃部署路径**（那是 \`compose/\` + Doco-CD）。其中 13 个文件引用同一个已退休的 \`x-evor\` 命名空间。

**没有批量替换**：accounts/console 发布在 \`ai-workspace-services\`，postgresql/stunnel 发布在 \`ai-workspace-infra\`——两个不同 org；\`observability-stack\` 的正确路径完全没核实过。13 个文件不加区分地猜一个命名空间，正是这个会话大半时间都在清除的那类缺陷。README 里记录了哪些已确认、哪些是猜测、哪些完全未核实，供以后真正启用这条路线的人接手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)