### PR TITLE
feat(web-saas): caddy with cloudflare dns + dedicated env_file

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -20,7 +20,16 @@ ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.07.28
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.07.28
 CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.07.28
 
-CADDY_IMAGE=caddy:2-alpine
+# 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
+# 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换
+# 之前必然签不出证书。换成带 caddy-dns/cloudflare 的自建镜像后走 ACME DNS-01,
+# 并签一张 *.onwalk.net 泛域名证书(Caddyfile 由 playbooks 的
+# web_saas_host_config 渲染, 见 ai-workspace-infra/playbooks#203)。
+#
+# 钉 short-sha 而不是 :latest —— caddy 是直接终结 TLS 的组件, 浮动 tag 会让
+# "同一份 gitops 提交部署出行为不同的 TLS 栈", 那是最不该有的不确定性。
+# 镜像由 ai-workspace-infra/artifacts 的 build-ci-image-caddy.yml 构建。
+CADDY_IMAGE=ghcr.io/ai-workspace-infra/caddy-cloudflare:959d6c8
 
 # 基础组件不随业务发布走 deploy_tag, 钉在验证过的版本上, 单独升级。
 # 这三个镜像由 ai-workspace-infra/postgresql.svc.plus 的 ci-pipeline.yml

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -181,8 +181,17 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    # 只有 caddy 读这个文件, 里面是 ACME DNS-01 用的 CLOUDFLARE_DNS_API_TOKEN。
+    # 刻意不并进 secrets.env —— 那个文件被 postgres / accounts / billing /
+    # console 四个服务同时引用, 而这个 token 能改整个 zone 的解析记录。
+    # 由 playbooks 的 web_saas_host_config 渲染成 0600。
+    env_file:
+      - /etc/xcontrol/web-saas/caddy.env
     volumes:
       - /etc/xcontrol/web-saas/Caddyfile:/etc/caddy/Caddyfile:ro
+      # caddy_data 存证书与 ACME 账户密钥。主机重建会连卷一起丢, 于是每次
+      # 重建都要重新签发, 撞 Let's Encrypt "同一组域名 5 次/周" 的限流 ——
+      # 平台侧会把它备份进 Vault 并在 bootstrap 时恢复, 让重建不再重签。
       - caddy_data:/data
       - caddy_config:/config
     networks:


### PR DESCRIPTION
三步接线的第 2 步。依赖 ai-workspace-infra/artifacts#183(已合并)与 ai-workspace-infra/playbooks#203(渲染 `caddy.env` 与泛域名 Caddyfile)。

## 改了什么

**1. `CADDY_IMAGE` 换成带 `caddy-dns/cloudflare` 的自建镜像**

官方 `caddy:2-alpine` 不含任何 DNS provider 模块,只能走 HTTP-01 —— 那要求域名 A 记录已经指向本机,而交付顺序是「先部署新主机、最后才切 DNS」,切换之前必然签不出证书。

钉 **short-sha 而不是 `:latest`**:caddy 是直接终结 TLS 的组件,浮动 tag 会让「同一份 gitops 提交部署出行为不同的 TLS 栈」,那是最不该有的不确定性。已确认 `959d6c8` 在 GHCR 真实存在。

**2. 给 caddy 补 `env_file`**

caddy 服务此前**根本没有 `env_file`**,因此拿不到任何 token —— 这是接 DNS-01 绕不过去的一步,也是之前设计里最容易被忽略的一处。

单独挂 `/etc/xcontrol/web-saas/caddy.env`,**不复用 `secrets.env`**:后者被 postgres / accounts / billing / console 四个服务同时引用,而这个 token 能改整个 zone 的解析记录。最小权限。文件由 playbooks 渲染成 0600。

## 范围

只改 `web-saas`。`agent-proxy` / `open-platform` / `ai-workspace` 三个域也用 `CADDY_IMAGE`,但它们不需要 DNS-01,保持 `caddy:2-alpine` 不动。

## 合并顺序

playbooks#203 需要**先合**,否则 `caddy.env` 不存在 —— compose 的 `env_file` 指向不存在的文件会导致 caddy 启动失败。playbooks#203 本身是向后兼容的(没 token 就退回 HTTP-01),先合它没有风险。

## 关于限流的预期

泛域名把每次重建的签发从 3 张降到 1 张,但 Let's Encrypt「同一组域名 5 次/周」**仍然成立**。真正做到无限次重建靠第 3 步:把 `caddy_data` 备份进 Vault、bootstrap 时恢复,让重建不再触发重签。

🤖 Generated with [Claude Code](https://claude.com/claude-code)