### PR TITLE
fix(uat): pin all domain images to immutable refs

### DIFF
--- a/compose/agent-proxy/.env.uat
+++ b/compose/agent-proxy/.env.uat
@@ -4,15 +4,14 @@
 # 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/agent-proxy/secrets.env，
 # 由 Ansible 从 Vault 渲染，不进本仓库。
 #
-# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md，UAT 的
-# deploy_tag 恒为 latest；要钉死某次构建就把对应条目换成 sha-<40 位>。
+# 每个镜像必须显式固定到不可变 tag 或 digest；禁止使用 latest。
 
 # 基础组件
-POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
-STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
-STUNNEL_CLIENT_IMAGE=dweomer/stunnel@sha256:c46e11e6cc135275566de318d739f815c272c23084fc1e65704f7e228992e9ef
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:sha-7759f4513e1710e86332795b611507bbed37ea39
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:sha-7759f4513e1710e86332795b611507bbed37ea39
+STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:sha-7759f4513e1710e86332795b611507bbed37ea39
 
-CADDY_IMAGE=caddy:2-alpine
+CADDY_IMAGE=ghcr.io/ai-workspace-infra/caddy-cloudflare:959d6c8
 
 # stunnel-client 需要知道的外部 postgresql 主机（stunnel-server 所在节点）
 # 生产中填写目标主机的 IP 或域名；此处为 UAT 占位符，由 Ansible 渲染 secrets.env 覆盖。

--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -4,8 +4,7 @@
 # 只放镜像引用。口令与 token 在主机的 /etc/xcontrol/web-saas/secrets.env,
 # 由 Ansible 从 Vault 渲染, 不进本仓库。
 #
-# 按 platform-ops-toolkit docs/domains/IMAGE-TAG-CONTRACT.md, UAT 的
-# deploy_tag 恒为 latest; 要钉死某次构建就把对应条目换成 sha-<40 位>。
+# 每个镜像必须显式固定到不可变 tag 或 digest；禁止使用 latest。
 #
 # 2026-07-28: 本次显式钉在跨仓日快照 tag uat-daily-build-2026-07-28-r3 上,
 # 而不是 latest。理由是 latest 按仓库各自的 main 走, 三个服务的 main 时间
@@ -14,7 +13,6 @@
 # 组互不对齐的版本。日快照 tag 是同一轮打在四个 org 各仓 main 上的, 三个
 # 镜像同属一个横切点, 这才是"一次可复现的 UAT 部署"该有的语义。
 # 三个 tag 均已在 GHCR 核实存在(digest 见 PR 描述)。
-# 回到滚动模式: 把三行换回 :latest 即可。
 
 ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.07.30-r2
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.07.30-r2
@@ -37,9 +35,9 @@ CADDY_IMAGE=ghcr.io/ai-workspace-infra/caddy-cloudflare:959d6c8
 # ai-workspace-infra 之前留下的旧路径), 已在 CI 侧退休
 # (postgresql.svc.plus#19)、下面这三行同步改为当前实际发布路径。
 # 已在主机上用 docker manifest inspect 逐个确认这三个 tag 真实存在。
-POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:latest
-STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:latest
-STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:latest
+POSTGRESQL_IMAGE=ghcr.io/ai-workspace-infra/postgresql:sha-7759f4513e1710e86332795b611507bbed37ea39
+STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:sha-7759f4513e1710e86332795b611507bbed37ea39
+STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:sha-7759f4513e1710e86332795b611507bbed37ea39
 
 # 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
 DEPLOY_ENV=uat


### PR DESCRIPTION
## Outcome
- Keep the web-saas business set pinned to `daily-build-2026.07.30-r2`.
- Replace all UAT `latest` base-image references for web-saas and agent-proxy with published immutable SHA tags.
- Pin agent-proxy Caddy to the published Cloudflare-enabled image.

## Links
- Related UAT deployment: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30547765963

## Verification
- Confirmed selected package tags exist through the GitHub Packages API.
- Checked each UAT `_IMAGE` declaration is explicit and non-`latest`.
- `git diff --check`.