### PR TITLE
fix(web-saas): pin CONSOLE_IMAGE to uat-daily-build-2026.07.31-r1

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -13,10 +13,16 @@
 # 组互不对齐的版本。日快照 tag 是同一轮打在四个 org 各仓 main 上的, 三个
 # 镜像同属一个横切点, 这才是"一次可复现的 UAT 部署"该有的语义。
 # 三个 tag 均已在 GHCR 核实存在(digest 见 PR 描述)。
-
+#
+# 2026-07-31: 只把 CONSOLE_IMAGE 单独钉到 uat-daily-build-2026.07.31-r1 —— 本
+# 轮修的是 console 域 Caddy 路由劫持 + console 的 Next BFF(playbooks#210、
+# portal#127，复盘见 playbooks docs/cases/runbooks/2026-07-31-console-api-auth-bff-hijack.md)，
+# accounts/billing 代码未动，没有理由跟着挪版本、平白扩大这次变更的差异面。
+# "三个镜像同属一个横切点"这条原则约束的是"没有理由单独升级时不要各自
+# 悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。
 ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.07.30
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.07.30
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.07.30
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.07.31-r1
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## 背景

console 域下 `/api/auth/*` 被 Caddy 反代劫持到 accounts 服务，导致 console 自己的 Next BFF 路由（MFA 绑定的四个端点）全废。用户侧现象：`/panel/account?setupMfa=1` 绑定弹窗密钥框空白、二维码不渲染。

完整复盘：`playbooks` 仓 `docs/cases/runbooks/2026-07-31-console-api-auth-bff-hijack.md`

## 修复分两处，均已合并

- ai-workspace-infra/playbooks#210 — 删掉 Caddy 里把 console 域 `/api/auth/*` 转给 accounts:8080 的规则
- ai-workspace-services/portal#127 — 修 BFF `mfa/verify` 打错的上游路径（`/mfa/verify` → `/mfa/totp/verify`）、字段名、以及陈旧 `xc_mfa_challenge` cookie 会把已登录用户判成会话过期的次生缺陷

两者都合并到了各自 main，并用 `daily-main-snapshot.yaml` 打出跨仓快照 tag `uat-daily-build-2026.07.31-r1`（[run](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30606010179)），已在 GHCR 上核实 `ghcr.io/ai-workspace-services/console:uat-daily-build-2026.07.31-r1` 存在。

## 本 PR

只把 `CONSOLE_IMAGE` 单独钉到这个 tag；`accounts`/`billing` 代码未动，留在 `daily-build-2026.07.30` 不变——本仓注释里"三个镜像同属一个横切点"约束的是"没理由时不要各自悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。

## 验证计划（合并后）

1. Doco-CD 拉到新 commit 后自动重建 `web-saas-console`；
2. `curl -X POST https://console-uat.onwalk.net/api/auth/mfa/setup` 从 `404 text/plain` 变成 `400 application/json`；
3. 浏览器走完整 MFA 绑定流程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)