### PR TITLE
feat(web-saas): mount the restored wildcard cert dir into caddy

### DIFF
--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -193,8 +193,17 @@ services:
       - /etc/xcontrol/web-saas/caddy.env
     volumes:
       - /etc/xcontrol/web-saas/Caddyfile:/etc/caddy/Caddyfile:ro
-      # caddy_data 存证书与 ACME 账户密钥。主机重建会连卷一起丢, 于是每次
-      # 重建都要重新签发, 撞 Let's Encrypt "同一组域名 5 次/周" 的限流 ——
+      # 平台侧从 Vault 恢复下来的泛域名证书。Caddyfile 在这些文件存在时会用
+      # `tls <fullchain> <key>` 直接指过去, 完全不走 ACME —— 这是"证书在有效期
+      # 内无限复用"真正生效的一环。容器内路径必须与主机侧一致, 因为 Caddyfile
+      # 里写的是绝对路径, 由 playbooks 渲染时按主机路径生成。
+      #
+      # 目录整体挂载而不是逐文件: current 是个软链, 指向 versions/<指纹>/,
+      # 证书轮换时整体原子替换。逐文件挂载会把 bind mount 钉死在旧 inode 上,
+      # 主机换了证书容器里还是旧的。
+      - /etc/xcontrol/tls:/etc/xcontrol/tls:ro
+      # caddy_data 存 ACME 账户密钥与自行签发的证书。主机重建会连卷一起丢,
+      # 走 ACME 时每次重建都要重新签发, 撞 Let's Encrypt "同一组域名 5 次/周" 的限流 ——
       # 平台侧会把它备份进 Vault 并在 bootstrap 时恢复, 让重建不再重签。
       - caddy_data:/data
       - caddy_config:/config


### PR DESCRIPTION
配合 ai-workspace-infra/playbooks#213。

## 为什么需要

playbooks#213 让 Caddyfile 在磁盘上存在恢复下来的证书时,用 `tls <fullchain> <key>` 直接指过去(完全不走 ACME)。但那些文件在**主机**的 `/etc/xcontrol/tls/`,容器里看不到 —— 不挂进去的话 Caddy 起来就是 `open ...: no such file or directory`,**比走 ACME 更糟**:容器直接起不来。

## 两个细节

**目录整体挂载,不是逐文件。** `current` 是个软链,指向 `versions/<证书指纹>/`,轮换时整体原子替换。逐文件 bind mount 会把挂载钉死在旧 inode 上,主机换了证书容器里还是旧的 —— 而且这种情况**不会报错**,只会安静地继续用过期证书,直到某天 TLS 握手开始失败。

**只读。** 容器没有任何理由改写这些文件。

## 合并顺序

playbooks#213 与本 PR 谁先合都不会破坏现状:
- 只合本 PR:多挂一个目录,Caddyfile 还是 ACME 模式,行为不变
- 只合 #213:Caddyfile 指向容器内不存在的路径 → **caddy 起不来**

所以建议**本 PR 先合**,或两个一起合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)