### PR TITLE
chore(gitops): pin UAT usage billing release

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -20,9 +20,13 @@
 # accounts/billing 代码未动，没有理由跟着挪版本、平白扩大这次变更的差异面。
 # "三个镜像同属一个横切点"这条原则约束的是"没有理由单独升级时不要各自
 # 悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.07.31
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.07.31
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.07.31
+#
+# 2026-08-01: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
+# 最小闭环。三项服务共同固定在同一 tag：Billing 修复多 inbound 的 UUID 聚合，
+# Accounts 记录周期并增量返回配额汇总，Console 显示月度配额卡。不可混用 latest。
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.08.01-r1
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.08.01-r1
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.08.01-r1
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome

Pins the UAT web-saas application images to the shared immutable `daily-build-2026.08.01-r1` release.

- Billing includes the merged UUID aggregation fix for multi-inbound Xray samples.
- Accounts includes monthly quota-period persistence and additive usage-summary fields.
- Console includes the monthly quota progress card.
- PostgreSQL, stunnel, Caddy, ports, secrets, and `DEPLOY_ENV=uat` remain unchanged.

## Links

- Billing: https://github.com/ai-workspace-services/billing-service/pull/24
- Accounts: https://github.com/ai-workspace-services/accounts/pull/45
- Portal: https://github.com/ai-workspace-services/portal/pull/130
- Repository issues are disabled or no issue was supplied.

## Verification

- Tag build succeeded for Billing, Accounts, and Portal before this GitOps change.
- GitOps PR check verifies that every declared image resolves in GHCR.
- UAT validation will run only after merge against `console-uat.onwalk.net` and the supplied UAT nodes.

No production endpoint or production environment configuration is changed.