### PR TITLE
chore(gitops): deploy accounts and console r2 to uat

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -24,9 +24,9 @@
 # 2026-08-01: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
 # 最小闭环。三项服务共同固定在同一 tag：Billing 修复多 inbound 的 UUID 聚合，
 # Accounts 记录周期并增量返回配额汇总，Console 显示月度配额卡。不可混用 latest。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.08.01-r1
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.08.01-r2
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.08.01-r1
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.08.01-r1
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.08.01-r2
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome

Updates only the UAT web-saas image references required by the next Xray usage billing rollout checkpoint. Accounts receives the shared accounting schema bootstrap and Portal receives the account dashboard layout; Billing remains pinned to its previously validated r1 image.

## Changes

- ACCOUNTS_IMAGE: daily-build-2026.08.01-r2
- CONSOLE_IMAGE: daily-build-2026.08.01-r2
- BILLING_IMAGE remains daily-build-2026.08.01-r1

## Links

- Accounts shared schema bootstrap: https://github.com/ai-workspace-services/accounts/pull/46
- Portal account dashboard: https://github.com/ai-workspace-services/portal/pull/131
- Prior UAT image baseline: https://github.com/ai-workspace-infra/gitops/pull/129

## Verification

- Both r2 service tag pipelines completed successfully.
- git diff --check
- Image references are explicit immutable daily-build tags; latest is not used.

## Scope

No service code, Vault/secret, database, production, agent-proxy, or Observability changes. Doco-CD will reconcile this UAT-only GitOps main change after merge.