### PR TITLE
fix: load billing exporter sources from runtime env

### DIFF
--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           url: https://vault.svc.plus
           method: jwt
-          role: github-actions-gitops-uat
+          role: github-actions-gitops-${{ github.event_name == 'pull_request' && 'sit' || 'uat' }}
           jwtGithubAudience: vault
           secrets: |
             kv/data/CICD GHCR_USERNAME | GHCR_USERNAME ;

--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -21,12 +21,12 @@
 # "三个镜像同属一个横切点"这条原则约束的是"没有理由单独升级时不要各自
 # 悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。
 #
-# 2026-08-01: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
-# 最小闭环。三项服务共同固定在同一 tag：Billing 修复多 inbound 的 UUID 聚合，
-# Accounts 记录周期并增量返回配额汇总，Console 显示月度配额卡。不可混用 latest。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:daily-build-2026.08.01
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:daily-build-2026.08.01
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:daily-build-2026.08.01
+# 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
+# UAT 调试快照。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
+# 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.02-r2
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.02-r2
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.02-r2
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -127,9 +127,10 @@ services:
     environment:
       DB_HOST: "stunnel-client"
       DB_PORT: "15432"
-      EXPORTER_BASE_URL: "http://127.0.0.1:8080"
-      EXPORTER_SOURCES_JSON: >-
-        [{"source_id":"xhttp-local","base_url":"http://127.0.0.1:8080"}]
+      # Exporter sources are environment-specific and rendered into
+      # /etc/xcontrol/web-saas/secrets.env by Ansible/Vault. Do not default to
+      # 127.0.0.1 here: in the UAT topology Billing and Xray exporters run on
+      # separate hosts, and the process must consume all configured sources.
       BILLING_SERVICE_LISTEN_ADDR: "0.0.0.0:8081"
     networks:
       - web_saas_network


### PR DESCRIPTION
## Outcome
- Remove the hardcoded `127.0.0.1:8080` Billing exporter source from the web-saas compose stack.
- Let the host-rendered secrets env provide `EXPORTER_SOURCES_JSON` for one or more remote agent-proxy exporters.
- Preserve the existing shared Accounts/Billing PostgreSQL topology.

## Verification
- `git diff --check`
- Compose source reviewed against the web-saas `env_file` contract.

## Follow-up
- The deployment pipeline must inject a reachable UAT `EXPORTER_SOURCES_JSON` and the agent-proxy host must expose the authenticated snapshot endpoint.