### PR TITLE
chore(uat): pin web saas to 2026.08.02-r3

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -22,11 +22,11 @@
 # 悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。
 #
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
-# UAT 调试快照。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
+# UAT 调试快照 r3。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.02-r2
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.02-r2
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.02-r2
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.02-r3
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.02-r3
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.02-r3
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
- Pin Accounts, Billing, and Console to `uat-daily-build-2026.08.02-r3` in the UAT release axis.
- Keep the separately managed xray-exporter pin unchanged at `v0.6.0-uat.20260802.1`.

## Verification
- `git diff --check`
- Confirmed only `compose/web-saas/.env.uat` image pins changed.

## Context
- Cross-repository snapshot: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30738321811
- This commit is the pull-only CD input; it does not modify production configuration.