### PR TITLE
chore(uat): pin web saas to 2026.08.02-r4

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -22,11 +22,11 @@
 # 悬空在不同的 main 时间点"，不是"任何一次改动都必须三个一起挪"。
 #
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
-# UAT 调试快照 r3。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
+# UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.02-r3
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.02-r3
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.02-r3
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.02-r4
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.02-r4
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.02-r4
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
- Pin Accounts, Billing, and Console to `uat-daily-build-2026.08.02-r4` for the complete UAT snapshot.
- Keep xray-exporter managed separately at `v0.6.0-uat.20260802.1`.
- The companion `agent.svc.plus` repository is being added to the same cross-repository snapshot so agent-proxy can checkout the deployment ref.

## Verification
- `git diff --check`
- r4 service images already passed the GitOps image declaration validation in PR #132; the immutable pins are changed only in `compose/web-saas/.env.uat`.

## Context
- Previous UAT run exposed the missing agent.svc.plus r3 tag: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30742827471
- r4 snapshot retry including agent.svc.plus: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/30743427197
- Pull-only CD input; no production configuration is changed.