### PR TITLE
chore: default billing to Vector ingest

### DIFF
--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -127,10 +127,10 @@ services:
     environment:
       DB_HOST: "stunnel-client"
       DB_PORT: "15432"
-      # Exporter sources are environment-specific and rendered into
-      # /etc/xcontrol/web-saas/secrets.env by Ansible/Vault. Do not default to
-      # 127.0.0.1 here: in the UAT topology Billing and Xray exporters run on
-      # separate hosts, and the process must consume all configured sources.
+      # Usage snapshots arrive through Vector's authenticated ingest endpoint.
+      # Keep direct exporter pull disabled unless an operator explicitly sets
+      # BILLING_INGEST_MODE=pull during a rollback.
+      BILLING_INGEST_MODE: ${BILLING_INGEST_MODE:-push}
       BILLING_SERVICE_LISTEN_ADDR: "0.0.0.0:8081"
     networks:
       - web_saas_network


### PR DESCRIPTION
## What changed
- explicitly set BILLING_INGEST_MODE to push in the web-saas Billing container
- document that exporter pull is rollback-only

## Why
Keep the GitOps runtime default aligned with the Xray -> Exporter -> Vector -> Billing usage path.

## Verification
- git diff --check
- compose interpolation reviewed

## Safety
No production deployment or database change.