### PR TITLE
chore(uat): advance web-saas to OTEL snapshot r5

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -24,9 +24,9 @@
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
 # UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r4
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r4
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r4
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r5
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r5
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r5
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
Advance the UAT web-saas version axis to the cross-repository OTEL snapshot `uat-daily-build-2026.08.10-r5`.

This snapshot contains the merged Accounts, Billing, and Portal tracing changes and keeps all managed images on one immutable tag for pull-only CD.

## Verification
- Accounts snapshot workflow: https://github.com/ai-workspace-services/accounts/actions/runs/31387433212
- Billing snapshot workflow: https://github.com/ai-workspace-services/billing-service/actions/runs/31387440958
- Portal snapshot workflow: https://github.com/ai-workspace-services/portal/actions/runs/31387439405
- Cross-repository snapshot: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31387419122
- No Cloudflare Workers build is included in this deployment gate per request.