### PR TITLE
chore(uat): promote web-saas r6 snapshot

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -24,9 +24,9 @@
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
 # UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r5
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r5
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r5
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r6
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r6
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r6
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
Promote UAT web-saas accounts, billing, and console to the r6 snapshot that includes the merged console OTEL instrumentation runtime fix.

## Verification
- Snapshot workflow: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31389864166
- accounts r6 build: https://github.com/ai-workspace-services/accounts/actions/runs/31389881133
- billing r6 build: https://github.com/ai-workspace-services/billing-service/actions/runs/31389882608
- portal r6 build: https://github.com/ai-workspace-services/portal/actions/runs/31389886916
- Existing OTLP collector and 5% sampler settings remain unchanged.

## Deployment
After merge, the Playbooks UAT CD will validate the pinned refs and Doco-CD will pull the GitOps main revision.