### PR TITLE
chore(uat): promote web-saas r7 snapshot

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -24,9 +24,9 @@
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
 # UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r6
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r6
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r6
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r7
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r7
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r7
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
Promote UAT web-saas accounts, billing, and console to r7, which contains the Console runtime fix for Next.js instrumentation server chunks.

## Verification
- Snapshot workflow: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31391545735
- Portal fix PR: https://github.com/ai-workspace-services/portal/pull/175
- Portal r7 build completed successfully.
- Existing single `web-saas-otel-collector` topology and 5% trace sampler remain unchanged.

## Deployment
After merge, Playbooks UAT CD will validate the pins and Doco-CD will pull the GitOps main revision.