### PR TITLE
chore(uat): promote web-saas r11 snapshot

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -24,9 +24,9 @@
 # 2026-08-02: Xray → Exporter → Billing → PostgreSQL → Accounts → Portal
 # UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
-ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r10
-BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r10
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r10
+ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.10-r11
+BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.10-r11
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.10-r11
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
## Outcome
Promote the UAT web-saas image axis to `uat-daily-build-2026.08.10-r11` so the merged OTel gRPC exporter and correlation fields are deployed.

## Changes
- Accounts → `uat-daily-build-2026.08.10-r11`
- Billing → `uat-daily-build-2026.08.10-r11`
- Console → `uat-daily-build-2026.08.10-r11`

## Verification
- Daily Main Snapshot workflow `31402604633` completed successfully for all four organization matrix jobs.
- Service image build workflows for Accounts `31402636291`, Billing `31402643093`, and Portal `31402632652` completed successfully.
- This promotion is required before validating the private Collector gRPC path in UAT.