### PR TITLE
fix: configure UAT shared tenant domain

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -51,6 +51,10 @@ STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:sha-7759f4513e171
 
 # 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
 DEPLOY_ENV=uat
+# Accounts 以反向代理传入的租户主域解析 XWorkmate 同步请求。该值必须与
+# web-saas Caddyfile 的 X-Forwarded-Host 保持一致；禁止在服务代码中回退到
+# 任意共享域名，避免环境切换时把已登录用户解析到错误租户。
+XWORKMATE_SHARED_TENANT_DOMAINS=onwalk.net
 # Keep background traffic cheap; k6 requests retain their sampled W3C parent
 # and therefore remain fully observable during a test.
 OTEL_TRACES_SAMPLER_ARG=0.05

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -110,6 +110,9 @@ services:
       CONFIG_TEMPLATE: "/app/config/account.yaml"
       DB_HOST: "stunnel-client"
       DB_PORT: "15432"
+      # Must match the tenant domain forwarded by the environment Caddyfile.
+      # Kept in the environment manifest rather than compiled into Accounts.
+      XWORKMATE_SHARED_TENANT_DOMAINS: "${XWORKMATE_SHARED_TENANT_DOMAINS:?set in .env.<env>}"
       OTEL_SERVICE_NAME: "web-saas-accounts"
       OTEL_SERVICE_INSTANCE_ID: "web-saas-accounts"
       OTEL_ENVIRONMENT: "${DEPLOY_ENV:?set in .env.<env>}"


### PR DESCRIPTION
## Root cause

Web SaaS Caddy forwards `X-Forwarded-Host: onwalk.net`, but the GitOps compose manifest did not pass `XWORKMATE_SHARED_TENANT_DOMAINS` into Accounts. The Accounts image therefore could not resolve the shared tenant and Desktop reported `tenant was not found`.

## Change

- declare `XWORKMATE_SHARED_TENANT_DOMAINS=onwalk.net` in the UAT manifest
- require and pass the same value into the Accounts container

## Validation

- reviewed rendered Compose interpolation path; deployment verification will confirm the container environment and authenticated profile sync returns a tenant/profile result rather than `tenant_not_found`.