### PR TITLE
chore(cd): promote console r13 to UAT

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -26,7 +26,7 @@
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
 ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.12-r12
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.12-r12
-CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.12-r12
+CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.12-r13
 
 # 官方 caddy:2-alpine 不含任何 DNS provider 模块, 只能走 HTTP-01 —— 那要求
 # 域名 A 记录已经指向本机, 而交付顺序是"先部署新主机、最后才切 DNS", 切换


### PR DESCRIPTION
Promote only the Console image to the successful portal UAT build.

- CONSOLE_IMAGE: uat-daily-build-2026.08.12-r12 -> uat-daily-build-2026.08.12-r13
- Accounts and Billing remain on r12.
- Portal source PR: https://github.com/ai-workspace-services/portal/pull/210
- Image digest: sha256:ed05f367fcf07c7b33f805eaaee4b77d8dba2dc53e2a23579400fcc1b128d330