### PR TITLE
feat: deploy managed Bridge in UAT Web SaaS

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -25,6 +25,7 @@
 # UAT 调试快照 r4。Accounts/Billing/Console 使用同一跨仓 tag，便于按一次快照回溯
 # 统计链路；xray-exporter 由 agent-proxy 单独固定到同一快照对应的 v0.6.0 补丁构建。
 ACCOUNTS_IMAGE=ghcr.io/ai-workspace-services/accounts:uat-daily-build-2026.08.13-r2
+XWORKMATE_BRIDGE_IMAGE=ghcr.io/ai-workspace-lab/xworkmate-bridge:050977839b464870b0ba1b6d294046b601b8958c
 BILLING_IMAGE=ghcr.io/ai-workspace-services/billing-service:uat-daily-build-2026.08.13-r2
 CONSOLE_IMAGE=ghcr.io/ai-workspace-services/console:uat-daily-build-2026.08.13-r2
 
@@ -55,6 +56,7 @@ DEPLOY_ENV=uat
 # web-saas Caddyfile 的 X-Forwarded-Host 保持一致；禁止在服务代码中回退到
 # 任意共享域名，避免环境切换时把已登录用户解析到错误租户。
 XWORKMATE_SHARED_TENANT_DOMAINS=onwalk.net
+XWORKMATE_SHARED_TENANT_DOMAIN=onwalk.net
 # Keep background traffic cheap; k6 requests retain their sampled W3C parent
 # and therefore remain fully observable during a test.
 OTEL_TRACES_SAMPLER_ARG=0.05

--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -112,6 +112,7 @@ services:
       DB_PORT: "15432"
       # Must match the tenant domain forwarded by the environment Caddyfile.
       # Kept in the environment manifest rather than compiled into Accounts.
+      XWORKMATE_SHARED_TENANT_DOMAIN: "${XWORKMATE_SHARED_TENANT_DOMAIN:?set in .env.<env>}"
       XWORKMATE_SHARED_TENANT_DOMAINS: "${XWORKMATE_SHARED_TENANT_DOMAINS:?set in .env.<env>}"
       OTEL_SERVICE_NAME: "web-saas-accounts"
       OTEL_SERVICE_INSTANCE_ID: "web-saas-accounts"
@@ -128,6 +129,28 @@ services:
     depends_on:
       stunnel-client:
         condition: service_healthy
+
+  # Managed public ingress for Desktop/Web task sessions.  Credentials are
+  # validated by Accounts over the private compose network; no static user
+  # token is stored in GitOps.
+  bridge:
+    image: ${XWORKMATE_BRIDGE_IMAGE:?set in .env.<env>}
+    container_name: web-saas-xworkmate-bridge
+    restart: unless-stopped
+    env_file:
+      - /etc/xcontrol/web-saas/secrets.env
+    environment:
+      BRIDGE_ACCOUNTS_INTROSPECTION_URL: "http://accounts:8080/api/internal/bridge/credentials/introspect"
+      OTEL_SERVICE_NAME: "web-saas-xworkmate-bridge"
+      OTEL_SERVICE_INSTANCE_ID: "web-saas-xworkmate-bridge"
+      OTEL_ENVIRONMENT: "${DEPLOY_ENV:?set in .env.<env>}"
+    expose:
+      - "8787"
+    networks:
+      - web_saas_network
+    depends_on:
+      accounts:
+        condition: service_started
 
   billing:
     image: ${BILLING_IMAGE:?set in .env.<env>}
@@ -239,6 +262,8 @@ services:
       - web_saas_network
     depends_on:
       - accounts
+
+      - bridge
       - billing
       - console
       - otel-collector


### PR DESCRIPTION
## Changes
- run XWorkmate Bridge inside the Web SaaS compose network
- use private Accounts credential introspection and host-managed service token
- pin the current immutable Bridge image and pass the deployment shared tenant domain to Accounts

## Validation
- Compose YAML parse
- remote Compose configuration preflight