### PR TITLE
fix: reconcile web SaaS Caddy ingress

### DIFF
--- a/compose/web-saas/docker-compose.yml
+++ b/compose/web-saas/docker-compose.yml
@@ -236,6 +236,17 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    # Doco-CD recreates only services whose Compose configuration diverges.
+    # Keep an explicit runtime health check here so ingress configuration changes
+    # are part of Caddy's declared state; a merely "running" container is not
+    # enough evidence that the public listener was reconciled after a host
+    # replacement or stale Docker container recovery.
+    healthcheck:
+      test: ["CMD", "caddy", "validate", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     # 只有 caddy 读这个文件, 里面是 ACME DNS-01 用的 CLOUDFLARE_DNS_API_TOKEN。
     # 刻意不并进 secrets.env —— 那个文件被 postgres / accounts / billing /
     # console 四个服务同时引用, 而这个 token 能改整个 zone 的解析记录。


### PR DESCRIPTION
## Outcome
Force Doco-CD to reconcile the stale `web-saas-caddy` container through a meaningful Compose configuration change.

## Root cause
The live Caddy container was running but had no host `80/tcp` or `443/tcp` bindings, so the UAT Web SaaS IP refused connections and Agent Proxy could not fetch its runtime configuration. GitOps had no content change, so Doco-CD did not reconcile the stale container.

## Change
Add a Caddy health check to the Web SaaS Compose service. This changes the desired container configuration and lets Doco-CD recreate the divergent Caddy container while preserving the existing published ports.

## Verification
- Parsed `compose/web-saas/docker-compose.yml` successfully with Ruby YAML parser.
- Confirmed live diagnosis: Caddy was running with empty port bindings and no host listeners.

## Follow-up
After merge, run the UAT platform-ops deployment and verify Caddy publishes ports 80/443 before DNS/service checks.