### PR TITLE
fix: use database readiness for accounts

### DIFF
--- a/services/accounts/base/values.yaml
+++ b/services/accounts/base/values.yaml
@@ -14,7 +14,7 @@ service:
       HEALTHCHECK_PATH: /healthz
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /readyz
       port: http
     initialDelaySeconds: 10
     periodSeconds: 10


### PR DESCRIPTION
## Outcome

Route the Accounts readiness probe to `/readyz` so traffic is admitted only after the active database primary is reachable.

## Issue

- Keep liveness on `/healthz`.
- Align deployment probes with the single-primary VPS/Supabase switching model.

## Scope

- Updated: `services/accounts/base/values.yaml`
- Changed only `readinessProbe.httpGet.path`.
- No image, secret, database credential, or production routing changes.

## Verification

- `git diff --check`
- YAML change reviewed and limited to the Accounts base values file.

## Rollback

Revert the single probe-path change to restore readiness checks on `/healthz`.
