### PR TITLE
fix: use database readiness for accounts (public stunnel)

### DIFF
--- a/services/accounts/base/values.yaml
+++ b/services/accounts/base/values.yaml
@@ -14,7 +14,7 @@ service:
       HEALTHCHECK_PATH: /healthz
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /readyz
       port: http
     initialDelaySeconds: 10
     periodSeconds: 10


### PR DESCRIPTION
## Outcome\n- Route the public-stunnel Accounts readinessProbe to /readyz.\n- Keep liveness on /healthz.\n\n## Issue\n- N/A — aligns deployment probes with single-primary VPS/Supabase switching.\n\n## Verification\n- git diff --check\n- YAML change is limited to the Accounts base values file.