### PR TITLE
feat: declare dual-mode DNS and async DTS routing

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -1,53 +1,87 @@
-# Serverless edge routing configuration
+# Web SaaS dual-mode routing and database handover
 
-The UAT serverless delivery chain consumes one declarative configuration file:
+The UAT source of truth is:
 
 ```text
 resources/svc.plus/uat/cloudflare/edge-routing.yaml
 ```
 
-It is the configuration backend for:
+It defines exactly two runtime modes. `spec.mode` is the desired mode for the environment;
+the actual traffic switch is performed only by changing the canonical DNS CNAME target.
 
 ```text
-Supabase → Cloud Run → SSR Workers ×5 → edge-gateway Workers ×3 → Pages → Verify
+VPS mode
+DNS → VPS Full Stack → Console / Accounts / Content / Billing
+                    → self-managed PostgreSQL
+
+Serverless mode
+DNS → Cloudflare Pages → SSR ×5 → edge-gateway ×3
+                      → Cloud Run: accounts / content-service / billing-service
+                      → Supabase Cloud DB
 ```
 
-The YAML declaration contains only non-sensitive values:
+## Canonical DNS contract
 
-- Cloudflare zone, Pages project, and environment domains;
-- SSR Worker names and route suffixes;
-- edge-gateway Worker names and API routes;
-- VPS and Cloud Run origin URLs;
-- primary/fallback routing policy.
+UAT keeps stable canonical hostnames and uses a 60-second TTL:
 
-Cloudflare tokens, Vault tokens, JWT secrets, database credentials, and service-account
-credentials remain runtime inputs from Vault/OIDC. A deployment must fail when the selected
-GitOps ref does not contain the expected declaration.
+| Canonical hostname | VPS CNAME | Serverless CNAME |
+| --- | --- | --- |
+| `console-uat.onwalk.net` | `console-vps-uat.onwalk.net` | `console-cloudflare-uat.onwalk.net` |
+| `accounts-uat.onwalk.net` | `accounts-vps-uat.onwalk.net` | `accounts-cloudflare-uat.onwalk.net` |
 
-## Definition contract
+The UAT declaration defaults to `serverless`. DNS is the only top-level traffic switch;
+health checks must not silently rewrite the selected mode.
 
-The file is a single `EdgeRoutingConfig` document with these required fields:
+The production naming contract follows the same shape:
 
-| Path | Type | Requirement |
-|---|---|---|
-| `apiVersion` | string | `gitops.svc.plus/v1alpha1` |
-| `kind` | string | `EdgeRoutingConfig` |
-| `metadata.environment` | string | Matches the selected environment directory |
-| `spec.cloudflare.zone_name` | string | Cloudflare zone name |
-| `spec.cloudflare.pages_project` | string | Pages project name |
-| `spec.hosts.console_cloudflare` | string | Console Cloudflare hostname |
-| `spec.hosts.accounts_cloudflare` | string | Accounts Cloudflare hostname |
-| `spec.hosts.console_vps` | string | VPS console fallback hostname |
-| `spec.hosts.accounts_vps` | string | VPS Accounts primary/fallback hostname |
-| `spec.ssr` | list | Exactly five independently deployable boundaries |
-| `spec.edge_gateway.boundaries` | list | `auth`, `admin`, and `core`; `core` must use `/api/*` |
-| `spec.edge_gateway.defaults` | map | Public upstream and timeout policy; no secrets |
+| Canonical hostname | VPS CNAME | Serverless CNAME |
+| --- | --- | --- |
+| `console.svc.plus` | `console-vps-prod.svc.plus` | `console-cloudflare-prod.svc.plus` |
+| `accounts.svc.plus` | `accounts-vps-prod.svc.plus` | `accounts-cloudflare-prod.svc.plus` |
 
-Every Worker name and route is declared once here. Consumers must not override these values
-with repository-local environment-specific constants. Add SIT or production only by creating
-the corresponding environment-scoped YAML file and validating it before enabling that
-environment.
+Production must be introduced through its own environment-scoped declaration and PR; the UAT
+file does not enable production traffic.
 
-To test a branch of this repository from the orchestrator, set `gitops_ref` to that branch in
-the manual dispatch. Production and SIT declarations should be added under their own
-`resources/svc.plus/<env>/cloudflare/` path before those environments are enabled.
+## Database handover and async DTS reservation
+
+Both database targets are declared so the two runtime modes can be prepared and switched without
+changing application configuration at the last moment:
+
+- VPS mode uses self-managed PostgreSQL.
+- Serverless mode uses Supabase Cloud DB.
+- `database.dts.enabled` is `false` until an engine, network path, slot/publication policy, and
+  cutover runbook have been approved.
+- The reserved DTS contract is asynchronous and declares both directions, a shared checkpoint
+  Vault reference, a 60-second maximum lag target, and a required quiesce window.
+- `single_writer: true` is mandatory. DTS does not imply dual-write or automatic failover.
+- Database connection strings, replication credentials, JWT secrets, Cloudflare tokens, and
+  service-account keys are never stored in GitOps; consumers resolve them from Vault/OIDC.
+
+Before switching the canonical CNAME, the operator must verify that the target database has caught
+up, freeze writes for the cutover window, promote exactly one writer, switch DNS, and then verify
+the selected mode. Rollback reverses the same order and must not delete or overwrite checkpoints.
+
+## Consumer contract
+
+Consumers must read the GitOps declaration rather than repository-local environment constants:
+
+- `spec.mode` and `spec.domains` define the two-mode contract.
+- `spec.cloudflare` defines the Pages project and zone.
+- `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries.
+- `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
+- `spec.database.modes` and `spec.database.dts` define database targets and the disabled DTS
+  reservation.
+
+The edge-gateway keeps its repository-mandated request-level VPS→Cloud Run failover for an
+individual request. That is an emergency resilience path, not the DNS mode switch: VPS mode is
+selected by canonical DNS, while the normal Serverless deployment chain remains
+Pages → SSR → edge-gateway → Cloud Run → Supabase.
+
+Deployment order is separate from request topology:
+
+```text
+Supabase → Cloud Run ×3 → SSR ×5 → edge-gateway ×3 → Pages → Verify
+```
+
+All declaration changes require a GitOps PR to `main` before the platform orchestrator consumes
+them.

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -1,4 +1,4 @@
-# Web SaaS dual-mode routing and database handover
+# Web SaaS runtime modes, routing, and database handover
 
 The UAT source of truth is:
 
@@ -6,8 +6,11 @@ The UAT source of truth is:
 resources/svc.plus/uat/cloudflare/edge-routing.yaml
 ```
 
-It defines exactly two runtime modes. `spec.mode` is the desired mode for the environment;
-the actual traffic switch is performed only by changing the canonical DNS CNAME target.
+The declaration exposes exactly three runtime modes:
+
+```text
+runtime.mode = vps | serverless | hybrid
+```
 
 ```text
 VPS mode
@@ -18,19 +21,40 @@ Serverless mode
 DNS → Cloudflare Pages → SSR ×5 → edge-gateway ×3
                       → Cloud Run: accounts / content-service / billing-service
                       → Supabase Cloud DB
+
+Hybrid mode
+DNS → Cloudflare edge → edge-gateway
+                    → VPS primary → Cloud Run request-level fallback
 ```
+
+## Runtime contract
+
+`spec.runtime` is the single runtime control plane:
+
+- `mode` selects `vps`, `serverless`, or `hybrid`.
+- `routing.dns` owns canonical DNS targets and the 60-second TTL.
+- `routing.load-balancer` declares the hybrid request-failover strategy.
+- `routing.weight` is reserved for explicit traffic weighting; it is not changed implicitly by
+  health checks.
+- `services` maps Console, Accounts, Content, and Billing to their mode-specific runtimes.
+- `data` declares primary/replica roles and the migration reservation.
+
+UAT currently declares `runtime.mode: hybrid`, with VPS weight 100 and Serverless weight 0. This
+keeps the required VPS→Cloud Run request-level failover explicit. A pure `serverless` rollout or
+DNS-only `vps` rollout is a deliberate GitOps change.
 
 ## Canonical DNS contract
 
-UAT keeps stable canonical hostnames and uses a 60-second TTL:
+Canonical hostnames remain stable; only their CNAME targets change:
 
 | Canonical hostname | VPS CNAME | Serverless CNAME |
 | --- | --- | --- |
 | `console-uat.onwalk.net` | `console-vps-uat.onwalk.net` | `console-cloudflare-uat.onwalk.net` |
 | `accounts-uat.onwalk.net` | `accounts-vps-uat.onwalk.net` | `accounts-cloudflare-uat.onwalk.net` |
 
-The UAT declaration defaults to `serverless`. DNS is the only top-level traffic switch;
-health checks must not silently rewrite the selected mode.
+DNS is the top-level switch for `vps` and `serverless`. `hybrid` adds request-level failover at
+edge-gateway: VPS is tried first for 2500 ms, then Cloud Run is retried on timeout, connection
+failure, or a 5xx response. The edge-gateway failover is not a silent DNS mutation.
 
 The production naming contract follows the same shape:
 
@@ -44,44 +68,31 @@ file does not enable production traffic.
 
 ## Database handover and async DTS reservation
 
-Both database targets are declared so the two runtime modes can be prepared and switched without
-changing application configuration at the last moment:
+`spec.runtime.data` reserves both database targets:
 
-- VPS mode uses self-managed PostgreSQL.
-- Serverless mode uses Supabase Cloud DB.
-- `database.dts.enabled` is `false` until an engine, network path, slot/publication policy, and
-  cutover runbook have been approved.
-- The reserved DTS contract is asynchronous and declares both directions, a shared checkpoint
-  Vault reference, a 60-second maximum lag target, and a required quiesce window.
-- `single_writer: true` is mandatory. DTS does not imply dual-write or automatic failover.
-- Database connection strings, replication credentials, JWT secrets, Cloudflare tokens, and
-  service-account keys are never stored in GitOps; consumers resolve them from Vault/OIDC.
+- `vps` uses self-managed PostgreSQL;
+- `serverless` uses Supabase Cloud DB;
+- `primary` and `replica` identify the current writer and prepared standby by mode;
+- `migration.enabled` is `false` until an engine, network path, slot/publication policy, and
+  cutover runbook have been approved;
+- the reserved migration is asynchronous, bidirectional, single-writer, and capped at a
+  60-second lag target with a required quiesce window;
+- connection strings, replication credentials, JWT secrets, Cloudflare tokens, and service
+  account keys are never stored in GitOps.
 
-Before switching the canonical CNAME, the operator must verify that the target database has caught
-up, freeze writes for the cutover window, promote exactly one writer, switch DNS, and then verify
-the selected mode. Rollback reverses the same order and must not delete or overwrite checkpoints.
+Before a mode or DNS cutover, the operator must validate lag, freeze writes, promote exactly one
+writer, apply the selected DNS/runtime mode, and run verification. Rollback reverses those steps
+without overwriting or deleting migration checkpoints.
 
 ## Consumer contract
 
-Consumers must read the GitOps declaration rather than repository-local environment constants:
+Consumers must read this GitOps declaration rather than repository-local environment constants:
 
-- `spec.mode` and `spec.domains` define the two-mode contract.
-- `spec.cloudflare` defines the Pages project and zone.
-- `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries.
+- `spec.runtime` defines mode, routing, services, and data handover;
+- `spec.domains` defines the canonical `vps` and `serverless` CNAME targets;
+- `spec.cloudflare` defines the Pages project and zone;
+- `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
-- `spec.database.modes` and `spec.database.dts` define database targets and the disabled DTS
-  reservation.
-
-The edge-gateway keeps its repository-mandated request-level VPS→Cloud Run failover for an
-individual request. That is an emergency resilience path, not the DNS mode switch: VPS mode is
-selected by canonical DNS, while the normal Serverless deployment chain remains
-Pages → SSR → edge-gateway → Cloud Run → Supabase.
-
-Deployment order is separate from request topology:
-
-```text
-Supabase → Cloud Run ×3 → SSR ×5 → edge-gateway ×3 → Pages → Verify
-```
 
 All declaration changes require a GitOps PR to `main` before the platform orchestrator consumes
 them.

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -9,11 +9,11 @@ resources/svc.plus/uat/cloudflare/edge-routing.yaml
 The declaration exposes exactly three runtime modes:
 
 ```text
-runtime.mode = vps | serverless | hybrid
+runtime.mode = selfhost | serverless | hybrid
 ```
 
 ```text
-VPS mode
+Selfhost mode
 DNS → VPS Full Stack → Console / Accounts / Content / Billing
                     → self-managed PostgreSQL
 
@@ -24,14 +24,15 @@ DNS → Cloudflare Pages → SSR ×5 → edge-gateway ×3
 
 Hybrid mode
 DNS → Cloudflare edge → edge-gateway
-                    → VPS primary → Cloud Run request-level fallback
+                    → selfhost primary → Cloud Run request-level fallback
 ```
 
 ## Runtime contract
 
 `spec.runtime` is the single runtime control plane:
 
-- `mode` selects `vps`, `serverless`, or `hybrid`.
+- `mode` selects `selfhost`, `serverless`, or `hybrid`. `selfhost` is the runtime mode name;
+  the physical target remains the existing VPS Full Stack.
 - `routing.dns` owns canonical DNS targets and the 60-second TTL.
 - `routing.load-balancer` declares the hybrid request-failover strategy.
 - `routing.weight` is reserved for explicit traffic weighting; it is not changed implicitly by
@@ -39,9 +40,9 @@ DNS → Cloudflare edge → edge-gateway
 - `services` maps Console, Accounts, Content, and Billing to their mode-specific runtimes.
 - `data` declares primary/replica roles and the migration reservation.
 
-UAT currently declares `runtime.mode: hybrid`, with VPS weight 100 and Serverless weight 0. This
-keeps the required VPS→Cloud Run request-level failover explicit. A pure `serverless` rollout or
-DNS-only `vps` rollout is a deliberate GitOps change.
+UAT currently declares `runtime.mode: hybrid`, with selfhost weight 100 and Serverless weight 0. This
+keeps the required Hybrid selfhost→Cloud Run request-level failover explicit. A pure `serverless`
+rollout or DNS-only `selfhost` rollout is a deliberate GitOps change.
 
 ## Canonical DNS contract
 
@@ -52,8 +53,8 @@ Canonical hostnames remain stable; only their CNAME targets change:
 | `console-uat.onwalk.net` | `console-vps-uat.onwalk.net` | `console-cloudflare-uat.onwalk.net` |
 | `accounts-uat.onwalk.net` | `accounts-vps-uat.onwalk.net` | `accounts-cloudflare-uat.onwalk.net` |
 
-DNS is the top-level switch for `vps` and `serverless`. `hybrid` adds request-level failover at
-edge-gateway: VPS is tried first for 2500 ms, then Cloud Run is retried on timeout, connection
+DNS is the top-level switch for `selfhost` and `serverless`. `hybrid` adds request-level failover at
+edge-gateway: selfhost is tried first for 2500 ms, then Cloud Run is retried on timeout, connection
 failure, or a 5xx response. The edge-gateway failover is not a silent DNS mutation.
 
 The production naming contract follows the same shape:
@@ -70,7 +71,7 @@ file does not enable production traffic.
 
 `spec.runtime.data` reserves both database targets:
 
-- `vps` uses self-managed PostgreSQL;
+- `selfhost` uses self-managed PostgreSQL;
 - `serverless` uses Supabase Cloud DB;
 - `primary` and `replica` identify the current writer and prepared standby by mode;
 - `migration.enabled` is `false` until an engine, network path, slot/publication policy, and
@@ -89,7 +90,7 @@ without overwriting or deleting migration checkpoints.
 Consumers must read this GitOps declaration rather than repository-local environment constants:
 
 - `spec.runtime` defines mode, routing, services, and data handover;
-- `spec.domains` defines the canonical `vps` and `serverless` CNAME targets;
+- `spec.domains` defines the canonical `selfhost` and `serverless` CNAME targets;
 - `spec.cloudflare` defines the Pages project and zone;
 - `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -57,6 +57,27 @@ DNS is the top-level switch for `selfhost` and `serverless`. `hybrid` adds reque
 edge-gateway: selfhost is tried first for 2500 ms, then Cloud Run is retried on timeout, connection
 failure, or a 5xx response. The edge-gateway failover is not a silent DNS mutation.
 
+## Cloudflare boundary split
+
+The Portal is deliberately built as five independent OpenNext SSR Workers, three independent
+edge-gateway Workers, and one Pages project. This split is required to keep each Cloudflare Worker
+artifact below the 3 MiB limit; the boundaries must not be recombined into a monolithic Worker.
+
+| Boundary | Worker / Pages project | Routes | Deployment unit |
+| --- | --- | --- | --- |
+| SSR public pages | `frontend-ssr-public-uat` | `/*`, `/_edge/public/*` | Independent lightweight Worker |
+| SSR content pages | `frontend-ssr-content-uat` | `/blogs*`, `/docs*`, `/download*` | Independent lightweight Worker |
+| SSR identity pages | `frontend-ssr-auth-uat` | `/login*`, `/register*`, etc. | Independent lightweight Worker |
+| SSR console | `frontend-ssr-console-uat` | `/panel*`, `/dashboard*` | Independent lightweight Worker |
+| SSR workspace | `frontend-ssr-workspace-uat` | `/ai-workspace*`, `/editor*`, etc. | Independent lightweight Worker |
+| API auth | `edge-gateway-auth-uat` | `accounts-cloudflare-uat.onwalk.net/api/auth/*` | Independent lightweight Worker |
+| API admin | `edge-gateway-admin-uat` | `accounts-cloudflare-uat.onwalk.net/api/admin/*` | Independent lightweight Worker |
+| API core | `edge-gateway-core-uat` | `accounts-cloudflare-uat.onwalk.net/api/*` fallback | Independent lightweight Worker |
+| Static assets | `ai-workspace-portal-uat` | `/static/*`, `/assets/*` | Pages deployment |
+
+The canonical names and complete route suffixes are declared in `spec.serverless.ssr` and
+`spec.serverless.edge_gateway`; the table is a human-readable summary of that contract.
+
 The production naming contract follows the same shape:
 
 | Canonical hostname | VPS CNAME | Serverless CNAME |

--- a/resources/svc.plus/uat/cloudflare/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/edge-routing.yaml
@@ -5,7 +5,56 @@ metadata:
   project: svc.plus
   environment: uat
 spec:
-  mode: serverless
+  runtime:
+    mode: hybrid
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
+      load-balancer:
+        strategy: request-failover
+        hybrid:
+          primary: vps
+          fallback: serverless
+      weight:
+        vps: 100
+        serverless: 0
+    services:
+      console:
+        vps: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        vps: vps-full-stack
+        serverless: cloud-run
+      content:
+        vps: vps-full-stack
+        serverless: cloud-run
+      billing:
+        vps: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: vps
+      providers:
+        vps: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/uat/serverless/dts
+        directions:
+          vps_to_serverless:
+            source: vps
+            target: serverless
+          serverless_to_vps:
+            source: serverless
+            target: vps
   domains:
     console-uat.onwalk.net:
       vps: console-vps-uat.onwalk.net
@@ -17,12 +66,6 @@ spec:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
     pages_branch: uat
-  dns:
-    control_plane: cloudflare-dns
-    ttl_seconds: 60
-    canonical_records:
-      console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
-      accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
   vps:
     stack: full-stack
     services:
@@ -39,44 +82,44 @@ spec:
       content_service: https://content-service-uc.a.run.app
       billing_service: https://billing-service-uc.a.run.app
     ssr:
-    - id: public
-      worker_name: frontend-ssr-public-uat
-      route_suffixes:
-        - /*
-        - /_edge/public/*
-    - id: content
-      worker_name: frontend-ssr-content-uat
-      route_suffixes:
-        - /blogs*
-        - /docs*
-        - /download*
-        - /_edge/content/*
-    - id: auth
-      worker_name: frontend-ssr-auth-uat
-      route_suffixes:
-        - /login*
-        - /register*
-        - /email-verification*
-        - /logout*
-        - /_edge/auth/*
-    - id: console
-      worker_name: frontend-ssr-console-uat
-      route_suffixes:
-        - /panel*
-        - /dashboard*
-        - /_edge/console/*
-    - id: workspace
-      worker_name: frontend-ssr-workspace-uat
-      route_suffixes:
-        - /ai-workspace*
-        - /cloud_iac*
-        - /editor*
-        - /support*
-        - /xworkmate*
-        - /_edge/workspace/*
+      - id: public
+        worker_name: frontend-ssr-public-uat
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-uat
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-uat
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-uat
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-uat
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
     edge_gateway:
       defaults:
-        # Required request-level failover contract; DNS remains the mode switch.
+        # These request-level failover values are active only in hybrid mode.
         primary_upstream: https://accounts-vps-uat.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
         jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
@@ -91,27 +134,3 @@ spec:
         - id: core
           worker_name: edge-gateway-core-uat
           route: /api/*
-  database:
-    modes:
-      vps:
-        provider: self-managed-postgresql
-        vault_ref: kv/uat/serverless/vps-postgresql
-      serverless:
-        provider: supabase
-        vault_ref: kv/uat/serverless/supabase
-    dts:
-      enabled: false
-      strategy: async
-      single_writer: true
-      max_lag_seconds: 60
-      require_quiesce_for_cutover: true
-      active_writer_mode: serverless
-      directions:
-        vps_to_serverless:
-          source: vps
-          target: serverless
-          checkpoint_vault_ref: kv/uat/serverless/dts
-        serverless_to_vps:
-          source: serverless
-          target: vps
-          checkpoint_vault_ref: kv/uat/serverless/dts

--- a/resources/svc.plus/uat/cloudflare/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/edge-routing.yaml
@@ -17,29 +17,29 @@ spec:
       load-balancer:
         strategy: request-failover
         hybrid:
-          primary: vps
+          primary: selfhost
           fallback: serverless
       weight:
-        vps: 100
+        selfhost: 100
         serverless: 0
     services:
       console:
-        vps: vps-full-stack
+        selfhost: vps-full-stack
         serverless: cloudflare-pages
       accounts:
-        vps: vps-full-stack
+        selfhost: vps-full-stack
         serverless: cloud-run
       content:
-        vps: vps-full-stack
+        selfhost: vps-full-stack
         serverless: cloud-run
       billing:
-        vps: vps-full-stack
+        selfhost: vps-full-stack
         serverless: cloud-run
     data:
       primary: serverless
-      replica: vps
+      replica: selfhost
       providers:
-        vps: self-managed-postgresql
+        selfhost: self-managed-postgresql
         serverless: supabase
       migration:
         enabled: false
@@ -49,18 +49,18 @@ spec:
         require_quiesce_for_cutover: true
         checkpoint_vault_ref: kv/uat/serverless/dts
         directions:
-          vps_to_serverless:
-            source: vps
+          selfhost_to_serverless:
+            source: selfhost
             target: serverless
-          serverless_to_vps:
+          serverless_to_selfhost:
             source: serverless
-            target: vps
+            target: selfhost
   domains:
     console-uat.onwalk.net:
-      vps: console-vps-uat.onwalk.net
+      selfhost: console-vps-uat.onwalk.net
       serverless: console-cloudflare-uat.onwalk.net
     accounts-uat.onwalk.net:
-      vps: accounts-vps-uat.onwalk.net
+      selfhost: accounts-vps-uat.onwalk.net
       serverless: accounts-cloudflare-uat.onwalk.net
   cloudflare:
     zone_name: onwalk.net

--- a/resources/svc.plus/uat/cloudflare/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/edge-routing.yaml
@@ -5,27 +5,40 @@ metadata:
   project: svc.plus
   environment: uat
 spec:
+  mode: serverless
+  domains:
+    console-uat.onwalk.net:
+      vps: console-vps-uat.onwalk.net
+      serverless: console-cloudflare-uat.onwalk.net
+    accounts-uat.onwalk.net:
+      vps: accounts-vps-uat.onwalk.net
+      serverless: accounts-cloudflare-uat.onwalk.net
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
     pages_branch: uat
-  hosts:
-    console_cloudflare: console-cloudflare-uat.onwalk.net
-    accounts_cloudflare: accounts-cloudflare-uat.onwalk.net
-    console_vps: console-vps-uat.onwalk.net
-    accounts_vps: accounts-vps-uat.onwalk.net
-  origins:
-    accounts_cloud_run: https://accounts-service-uc.a.run.app
-    content_cloud_run: https://content-service-uc.a.run.app
-    billing_cloud_run: https://billing-service-uc.a.run.app
-  routing:
-    console:
-      primary: cloudflare-pages
-      fallback: vps
-    accounts:
-      primary: vps
-      fallback: cloud-run
-  ssr:
+  dns:
+    control_plane: cloudflare-dns
+    ttl_seconds: 60
+    canonical_records:
+      console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
+      accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-uat.onwalk.net
+    accounts_host: accounts-cloudflare-uat.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
     - id: public
       worker_name: frontend-ssr-public-uat
       route_suffixes:
@@ -61,19 +74,44 @@ spec:
         - /support*
         - /xworkmate*
         - /_edge/workspace/*
-  edge_gateway:
-    defaults:
-      primary_upstream: https://accounts-vps-uat.onwalk.net
-      fallback_upstream: https://accounts-service-uc.a.run.app
-      jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
-      timeout_ms: '2500'
-    boundaries:
-      - id: auth
-        worker_name: edge-gateway-auth-uat
-        route: /api/auth/*
-      - id: admin
-        worker_name: edge-gateway-admin-uat
-        route: /api/admin/*
-      - id: core
-        worker_name: edge-gateway-core-uat
-        route: /api/*
+    edge_gateway:
+      defaults:
+        # Required request-level failover contract; DNS remains the mode switch.
+        primary_upstream: https://accounts-vps-uat.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-uat
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-uat
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-uat
+          route: /api/*
+  database:
+    modes:
+      vps:
+        provider: self-managed-postgresql
+        vault_ref: kv/uat/serverless/vps-postgresql
+      serverless:
+        provider: supabase
+        vault_ref: kv/uat/serverless/supabase
+    dts:
+      enabled: false
+      strategy: async
+      single_writer: true
+      max_lag_seconds: 60
+      require_quiesce_for_cutover: true
+      active_writer_mode: serverless
+      directions:
+        vps_to_serverless:
+          source: vps
+          target: serverless
+          checkpoint_vault_ref: kv/uat/serverless/dts
+        serverless_to_vps:
+          source: serverless
+          target: vps
+          checkpoint_vault_ref: kv/uat/serverless/dts


### PR DESCRIPTION
## Outcome

Defines the UAT runtime contract for three modes: Selfhost (VPS Full Stack) with self-managed PostgreSQL, Serverless with Cloudflare Pages/SSR/Cloud Run/Supabase, and Hybrid with edge-gateway request failover. Canonical DNS targets and a disabled async DTS reservation are now maintained in GitOps.

## Issue

- N/A — requested platform topology and database handover contract.

## Scope

- Added `spec.runtime.mode` (`selfhost`, `serverless`, `hybrid`), runtime routing/services/data declarations, and flat canonical `spec.domains`.
- Assigned Hybrid selfhost→Cloud Run request-level failover to Hybrid mode.
- Added self-managed PostgreSQL and Supabase modes plus a disabled, bidirectional async DTS reservation with single-writer and cutover guardrails.
- Rewrote the routing contract documentation.
- Intentionally did not enable replication, mutate DNS, or store database credentials.

## Verification

- Ruby YAML parse and contract assertions — passed.
- YAML-to-JSON rendering through the platform toolkit — passed.
- `git diff --check` — passed.
- External deployment and DNS cutover — not run; requires reviewed companion PRs and an approved change window.

## Risk / Security / Configuration

- UAT desired mode is `hybrid`; selfhost weight is 100 and Serverless weight is 0, with Cloud Run retained as the request-level fallback. Canonical DNS remains the top-level switch and TTL is 60 seconds.
- DTS is disabled by default and contains only non-sensitive Vault reference paths; no credentials or replication secrets were added.
- Production is documented but not enabled by this UAT declaration.

## Rollback

Revert this PR before merge, or set the environment declaration back to the previous GitOps contract. Do not delete tags or DTS checkpoints.

## Related

- Companion [platform-ops-toolkit PR #385](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/385) consumes this declaration.
- Companion [edge-gateway PR #7](https://github.com/ai-workspace-services/edge-gateway/pull/7) consumes `spec.serverless.edge_gateway`.
- Companion [portal PR #227](https://github.com/ai-workspace-services/portal/pull/227) consumes `spec.serverless.ssr`.
