### PR TITLE
feat: add selfhost serverless and hybrid routing profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,17 @@ scope.
 
 ### Serverless edge routing config backend
 
-Non-sensitive Cloudflare/Cloud Run/VPS routing for the web-saas domain is declared in
-`resources/<project>/<env>/cloudflare/edge-routing.yaml`. The serverless orchestrator checks
-out the selected GitOps ref and passes this file to the portal and edge-gateway deployers;
-those repositories do not own environment hostnames or Worker names. Keep tokens, passwords,
-JWT secrets, and database connection strings in Vault. The declaration may describe public
-origins and the primary/fallback routing policy.
+Non-sensitive Cloudflare/Cloud Run/VPS routing for the web-saas domain is declared as three
+mode-specific `EdgeRoutingConfig` documents under
+`resources/<project>/<env>/cloudflare/<mode>/edge-routing.yaml`, where `<mode>` is exactly
+`selfhost`, `serverless`, or `hybrid`. The orchestrator selects the document that matches its
+responsibility; it must not reinterpret one mode's declaration as another mode. These files
+are complete pre-configurations, not runtime secrets or deployment scripts.
+
+The serverless and hybrid orchestrators check out the selected GitOps ref and pass the matching
+file to the portal and edge-gateway deployers; those repositories do not own environment
+hostnames or Worker names. Keep tokens, passwords, JWT secrets, and database connection strings
+in Vault. The declarations may describe public origins and the primary/fallback routing policy.
 
 ## Layout
 

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -1,9 +1,11 @@
 # Web SaaS runtime modes, routing, and database handover
 
-The UAT source of truth is:
+The UAT mode-specific sources of truth are:
 
 ```text
-resources/svc.plus/uat/cloudflare/edge-routing.yaml
+resources/svc.plus/uat/cloudflare/selfhost/edge-routing.yaml
+resources/svc.plus/uat/cloudflare/serverless/edge-routing.yaml
+resources/svc.plus/uat/cloudflare/hybrid/edge-routing.yaml
 ```
 
 The declaration exposes exactly three runtime modes:
@@ -29,7 +31,7 @@ DNS → Cloudflare edge → edge-gateway
 
 ## Runtime contract
 
-`spec.runtime` is the single runtime control plane:
+Each file is a complete `EdgeRoutingConfig`; `spec.runtime` is its single runtime control plane:
 
 - `mode` selects `selfhost`, `serverless`, or `hybrid`. `selfhost` is the runtime mode name;
   the physical target remains the existing VPS Full Stack.
@@ -40,9 +42,14 @@ DNS → Cloudflare edge → edge-gateway
 - `services` maps Console, Accounts, Content, and Billing to their mode-specific runtimes.
 - `data` declares primary/replica roles and the migration reservation.
 
-UAT currently declares `runtime.mode: hybrid`, with selfhost weight 100 and Serverless weight 0. This
-keeps the required Hybrid selfhost→Cloud Run request-level failover explicit. A pure `serverless`
-rollout or DNS-only `selfhost` rollout is a deliberate GitOps change.
+The three UAT pre-configurations are intentionally explicit:
+
+- `selfhost`: DNS targets the VPS Full Stack, with selfhost as the database primary.
+- `serverless`: DNS targets Cloudflare Pages / edge-gateway, with Supabase as the database primary.
+- `hybrid`: selfhost is the request-level primary and Cloud Run is the edge-gateway fallback.
+
+The active traffic choice is made by selecting the matching declaration in the orchestrator; the
+pipeline must never validate or deploy against a different mode file.
 
 ## Canonical DNS contract
 
@@ -117,4 +124,5 @@ Consumers must read this GitOps declaration rather than repository-local environ
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
 
 All declaration changes require a GitOps PR to `main` before the platform orchestrator consumes
-them.
+them. Keep the three mode documents structurally aligned when changing shared domains, service
+names, database migration reservations, or Cloudflare boundary names.

--- a/resources/svc.plus/uat/cloudflare/hybrid/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/hybrid/edge-routing.yaml
@@ -4,6 +4,7 @@ metadata:
   name: web-saas
   project: svc.plus
   environment: uat
+  mode: hybrid
 spec:
   runtime:
     mode: hybrid
@@ -119,7 +120,6 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        # These request-level failover values are active only in hybrid mode.
         primary_upstream: https://accounts-vps-uat.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
         jwt_issuer: https://accounts-cloudflare-uat.onwalk.net

--- a/resources/svc.plus/uat/cloudflare/selfhost/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/selfhost/edge-routing.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: uat
+  mode: selfhost
+spec:
+  runtime:
+    mode: selfhost
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-uat.onwalk.net: console-vps-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-vps-uat.onwalk.net
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 100
+        serverless: 0
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: selfhost
+      replica: serverless
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/uat/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console-uat.onwalk.net:
+      selfhost: console-vps-uat.onwalk.net
+      serverless: console-cloudflare-uat.onwalk.net
+    accounts-uat.onwalk.net:
+      selfhost: accounts-vps-uat.onwalk.net
+      serverless: accounts-cloudflare-uat.onwalk.net
+  cloudflare:
+    zone_name: onwalk.net
+    pages_project: ai-workspace-portal-uat
+    pages_branch: uat
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-uat.onwalk.net
+    accounts_host: accounts-cloudflare-uat.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-uat
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-uat
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-uat
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-uat
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-uat
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-uat.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-uat
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-uat
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-uat
+          route: /api/*

--- a/resources/svc.plus/uat/cloudflare/serverless/edge-routing.yaml
+++ b/resources/svc.plus/uat/cloudflare/serverless/edge-routing.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: uat
+  mode: serverless
+spec:
+  runtime:
+    mode: serverless
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 0
+        serverless: 100
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: selfhost
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/uat/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console-uat.onwalk.net:
+      selfhost: console-vps-uat.onwalk.net
+      serverless: console-cloudflare-uat.onwalk.net
+    accounts-uat.onwalk.net:
+      selfhost: accounts-vps-uat.onwalk.net
+      serverless: accounts-cloudflare-uat.onwalk.net
+  cloudflare:
+    zone_name: onwalk.net
+    pages_project: ai-workspace-portal-uat
+    pages_branch: uat
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-uat.onwalk.net
+    accounts_host: accounts-cloudflare-uat.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-uat
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-uat
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-uat
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-uat
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-uat
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-uat.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-uat
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-uat
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-uat
+          route: /api/*


### PR DESCRIPTION
## Outcome

Add complete UAT GitOps routing pre-configurations for the three supported runtime modes:
`selfhost`, `serverless`, and `hybrid`.

## Issue

- The Serverless Orchestrator run failed because it consumed the active Hybrid declaration and
  rejected `runtime.mode: hybrid` while requiring `serverless`.
- Run: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32009226428

## Scope

- Add `cloudflare/selfhost/edge-routing.yaml`.
- Add `cloudflare/serverless/edge-routing.yaml`.
- Move the Hybrid declaration to `cloudflare/hybrid/edge-routing.yaml`.
- Document mode-specific selection and preserve the five SSR / three edge-gateway boundaries.
- Remove the ambiguous single `cloudflare/edge-routing.yaml` path.

## Verification

- Ruby YAML parsing passed for all three declarations.
- `metadata.mode` matches `spec.runtime.mode` for all three declarations.
- Serverless and Hybrid boundary contracts each validate with 9 boundaries.
- `git diff --check` passed.

## Risk / Security / Configuration

- No secrets or credentials added.
- Runtime routing policy is explicit per mode; Hybrid retains selfhost primary and Cloud Run
  request-level fallback.
- The active traffic mode is unchanged until a consumer selects a different declaration.

## Rollback

- Revert this PR to restore the previous single Hybrid declaration path.

## Related

- Follow-up toolkit PR updates the orchestrator workflows to consume the matching mode path.
