### PR TITLE
feat: add SIT and production runtime topology profiles

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -8,9 +8,9 @@ topology/<env>/selfhost/runtime-topology.yaml
 topology/<env>/hybrid/runtime-topology.yaml
 ```
 
-where `<env>` is `sit`, `uat`, or `prod`. The UAT declarations are currently populated; SIT and
-production declarations must be introduced with their environment-specific domains, origins,
-Worker names, and database topology before those workflow choices can deploy.
+where `<env>` is `sit`, `uat`, or `prod`. Each environment has its own domains, origins, Worker
+names, Pages project, and database topology; consumers must select the declaration matching both
+the requested environment and runtime mode.
 
 The mode directories intentionally are not nested under `cloudflare/`. These declarations cover
 the complete runtime topology—DNS, VPS Full Stack, Cloud Run, Supabase Cloud DB, and Cloudflare

--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -1,0 +1,136 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: prod
+  mode: hybrid
+spec:
+  runtime:
+    mode: hybrid
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console.svc.plus: console-cloudflare-prod.svc.plus
+          accounts.svc.plus: accounts-cloudflare-prod.svc.plus
+      load-balancer:
+        strategy: request-failover
+        hybrid:
+          primary: selfhost
+          fallback: serverless
+      weight:
+        selfhost: 100
+        serverless: 0
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: selfhost
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/prod/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console.svc.plus:
+      selfhost: console-vps-prod.svc.plus
+      serverless: console-cloudflare-prod.svc.plus
+    accounts.svc.plus:
+      selfhost: accounts-vps-prod.svc.plus
+      serverless: accounts-cloudflare-prod.svc.plus
+  cloudflare:
+    zone_name: svc.plus
+    pages_project: ai-workspace-portal-prod
+    pages_branch: prod
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-prod.svc.plus
+    accounts_host: accounts-cloudflare-prod.svc.plus
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-prod
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-prod
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-prod
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-prod
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-prod
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-prod.svc.plus
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-prod
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-prod
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-prod
+          route: /api/*

--- a/topology/prod/selfhost/runtime-topology.yaml
+++ b/topology/prod/selfhost/runtime-topology.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: prod
+  mode: selfhost
+spec:
+  runtime:
+    mode: selfhost
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console.svc.plus: console-vps-prod.svc.plus
+          accounts.svc.plus: accounts-vps-prod.svc.plus
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 100
+        serverless: 0
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: selfhost
+      replica: serverless
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/prod/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console.svc.plus:
+      selfhost: console-vps-prod.svc.plus
+      serverless: console-cloudflare-prod.svc.plus
+    accounts.svc.plus:
+      selfhost: accounts-vps-prod.svc.plus
+      serverless: accounts-cloudflare-prod.svc.plus
+  cloudflare:
+    zone_name: svc.plus
+    pages_project: ai-workspace-portal-prod
+    pages_branch: prod
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-prod.svc.plus
+    accounts_host: accounts-cloudflare-prod.svc.plus
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-prod
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-prod
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-prod
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-prod
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-prod
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-prod.svc.plus
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-prod
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-prod
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-prod
+          route: /api/*

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: prod
+  mode: serverless
+spec:
+  runtime:
+    mode: serverless
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console.svc.plus: console-cloudflare-prod.svc.plus
+          accounts.svc.plus: accounts-cloudflare-prod.svc.plus
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 0
+        serverless: 100
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: selfhost
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/prod/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console.svc.plus:
+      selfhost: console-vps-prod.svc.plus
+      serverless: console-cloudflare-prod.svc.plus
+    accounts.svc.plus:
+      selfhost: accounts-vps-prod.svc.plus
+      serverless: accounts-cloudflare-prod.svc.plus
+  cloudflare:
+    zone_name: svc.plus
+    pages_project: ai-workspace-portal-prod
+    pages_branch: prod
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-prod.svc.plus
+    accounts_host: accounts-cloudflare-prod.svc.plus
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-prod
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-prod
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-prod
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-prod
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-prod
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-prod.svc.plus
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-prod
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-prod
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-prod
+          route: /api/*

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -1,0 +1,136 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: sit
+  mode: hybrid
+spec:
+  runtime:
+    mode: hybrid
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-sit.onwalk.net: console-cloudflare-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-cloudflare-sit.onwalk.net
+      load-balancer:
+        strategy: request-failover
+        hybrid:
+          primary: selfhost
+          fallback: serverless
+      weight:
+        selfhost: 100
+        serverless: 0
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: selfhost
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/sit/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console-sit.onwalk.net:
+      selfhost: console-vps-sit.onwalk.net
+      serverless: console-cloudflare-sit.onwalk.net
+    accounts-sit.onwalk.net:
+      selfhost: accounts-vps-sit.onwalk.net
+      serverless: accounts-cloudflare-sit.onwalk.net
+  cloudflare:
+    zone_name: onwalk.net
+    pages_project: ai-workspace-portal-sit
+    pages_branch: sit
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-sit.onwalk.net
+    accounts_host: accounts-cloudflare-sit.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-sit
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-sit
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-sit
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-sit
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-sit
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-sit.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-sit
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-sit
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-sit
+          route: /api/*

--- a/topology/sit/selfhost/runtime-topology.yaml
+++ b/topology/sit/selfhost/runtime-topology.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: sit
+  mode: selfhost
+spec:
+  runtime:
+    mode: selfhost
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-sit.onwalk.net: console-vps-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-vps-sit.onwalk.net
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 100
+        serverless: 0
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: selfhost
+      replica: serverless
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/sit/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console-sit.onwalk.net:
+      selfhost: console-vps-sit.onwalk.net
+      serverless: console-cloudflare-sit.onwalk.net
+    accounts-sit.onwalk.net:
+      selfhost: accounts-vps-sit.onwalk.net
+      serverless: accounts-cloudflare-sit.onwalk.net
+  cloudflare:
+    zone_name: onwalk.net
+    pages_project: ai-workspace-portal-sit
+    pages_branch: sit
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-sit.onwalk.net
+    accounts_host: accounts-cloudflare-sit.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-sit
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-sit
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-sit
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-sit
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-sit
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-sit.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-sit
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-sit
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-sit
+          route: /api/*

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -1,0 +1,133 @@
+apiVersion: gitops.svc.plus/v1alpha1
+kind: EdgeRoutingConfig
+metadata:
+  name: web-saas
+  project: svc.plus
+  environment: sit
+  mode: serverless
+spec:
+  runtime:
+    mode: serverless
+    routing:
+      dns:
+        control_plane: cloudflare-dns
+        ttl_seconds: 60
+        canonical_records:
+          console-sit.onwalk.net: console-cloudflare-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-cloudflare-sit.onwalk.net
+      load-balancer:
+        strategy: dns-only
+      weight:
+        selfhost: 0
+        serverless: 100
+    services:
+      console:
+        selfhost: vps-full-stack
+        serverless: cloudflare-pages
+      accounts:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      content:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+      billing:
+        selfhost: vps-full-stack
+        serverless: cloud-run
+    data:
+      primary: serverless
+      replica: selfhost
+      providers:
+        selfhost: self-managed-postgresql
+        serverless: supabase
+      migration:
+        enabled: false
+        strategy: async
+        single_writer: true
+        max_lag_seconds: 60
+        require_quiesce_for_cutover: true
+        checkpoint_vault_ref: kv/sit/serverless/dts
+        directions:
+          selfhost_to_serverless:
+            source: selfhost
+            target: serverless
+          serverless_to_selfhost:
+            source: serverless
+            target: selfhost
+  domains:
+    console-sit.onwalk.net:
+      selfhost: console-vps-sit.onwalk.net
+      serverless: console-cloudflare-sit.onwalk.net
+    accounts-sit.onwalk.net:
+      selfhost: accounts-vps-sit.onwalk.net
+      serverless: accounts-cloudflare-sit.onwalk.net
+  cloudflare:
+    zone_name: onwalk.net
+    pages_project: ai-workspace-portal-sit
+    pages_branch: sit
+  vps:
+    stack: full-stack
+    services:
+      - console
+      - accounts
+      - content
+      - billing
+    database: self-managed-postgresql
+  serverless:
+    console_host: console-cloudflare-sit.onwalk.net
+    accounts_host: accounts-cloudflare-sit.onwalk.net
+    cloud_run:
+      accounts: https://accounts-service-uc.a.run.app
+      content_service: https://content-service-uc.a.run.app
+      billing_service: https://billing-service-uc.a.run.app
+    ssr:
+      - id: public
+        worker_name: frontend-ssr-public-sit
+        route_suffixes:
+          - /*
+          - /_edge/public/*
+      - id: content
+        worker_name: frontend-ssr-content-sit
+        route_suffixes:
+          - /blogs*
+          - /docs*
+          - /download*
+          - /_edge/content/*
+      - id: auth
+        worker_name: frontend-ssr-auth-sit
+        route_suffixes:
+          - /login*
+          - /register*
+          - /email-verification*
+          - /logout*
+          - /_edge/auth/*
+      - id: console
+        worker_name: frontend-ssr-console-sit
+        route_suffixes:
+          - /panel*
+          - /dashboard*
+          - /_edge/console/*
+      - id: workspace
+        worker_name: frontend-ssr-workspace-sit
+        route_suffixes:
+          - /ai-workspace*
+          - /cloud_iac*
+          - /editor*
+          - /support*
+          - /xworkmate*
+          - /_edge/workspace/*
+    edge_gateway:
+      defaults:
+        primary_upstream: https://accounts-vps-sit.onwalk.net
+        fallback_upstream: https://accounts-service-uc.a.run.app
+        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        timeout_ms: '2500'
+      boundaries:
+        - id: auth
+          worker_name: edge-gateway-auth-sit
+          route: /api/auth/*
+        - id: admin
+          worker_name: edge-gateway-admin-sit
+          route: /api/admin/*
+        - id: core
+          worker_name: edge-gateway-core-sit
+          route: /api/*


### PR DESCRIPTION
## Outcome
Complete the environment/mode topology matrix after the path migration in gitops#157.

Add the six missing declarations:

- `topology/sit/{serverless,selfhost,hybrid}/runtime-topology.yaml`
- `topology/prod/{serverless,selfhost,hybrid}/runtime-topology.yaml`

SIT uses isolated `onwalk.net` domains. Production uses the documented `svc.plus` canonical domains and `*-prod.svc.plus` origins. Existing stable Cloud Run origins are retained because no separate SIT/PROD Cloud Run endpoint values are declared elsewhere in the workspace.

## Issue
No issue link was supplied; this PR implements the requested SIT/PROD topology completion.

## Verification
- Parsed all nine topology YAML declarations successfully.
- Validated all six new serverless/hybrid declarations through the platform boundary contract checks.
- Confirmed environment-specific metadata, domains, Pages projects, branches, Worker names, and runtime modes.
- `git diff --check` passed.

## Dependency
The consumer workflow PR is [platform-ops-toolkit#389](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/389). The original path migration is merged in [gitops#157](https://github.com/ai-workspace-infra/gitops/pull/157).
