### PR TITLE
fix: configure UAT console Accounts endpoint

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -66,6 +66,8 @@ STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:sha-7759f4513e171
 
 # 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
 DEPLOY_ENV=uat
+ACCOUNT_SERVICE_URL=https://accounts-uat.onwalk.net
+NEXT_PUBLIC_ACCOUNT_SERVICE_URL=https://accounts-uat.onwalk.net
 # Accounts 以反向代理传入的租户主域解析 XWorkmate 同步请求。该值必须与
 # web-saas Caddyfile 的 X-Forwarded-Host 保持一致；禁止在服务代码中回退到
 # 任意共享域名，避免环境切换时把已登录用户解析到错误租户。


### PR DESCRIPTION
## Outcome
Configure the UAT Console runtime to call the UAT Accounts endpoint instead of falling back to the nonexistent accounts-cloudflare-uat.onwalk.net hostname.

## Links
- Run: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32022629745
- Related failure: https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32022629745

## Verification
- Confirmed on console-uat.onwalk.net over SSH that Console logged ENOTFOUND for accounts-cloudflare-uat.onwalk.net.
- Added ACCOUNT_SERVICE_URL and NEXT_PUBLIC_ACCOUNT_SERVICE_URL to compose/web-saas/.env.uat and passed them into the Console container.
- No credentials or secrets were added.