### PR TITLE
fix: align UAT serverless Cloud Run endpoints

### DIFF
--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -76,9 +76,9 @@ spec:
     console_host: console-cloudflare-uat.onwalk.net
     accounts_host: accounts-cloudflare-uat.onwalk.net
     cloud_run:
-      accounts: https://accounts-service-uc.a.run.app
-      content_service: https://content-service-uc.a.run.app
-      billing_service: https://billing-service-uc.a.run.app
+      accounts: https://uat-accounts-1004637461064.asia-northeast1.run.app
+      content_service: https://uat-content-service-1004637461064.asia-northeast1.run.app
+      billing_service: https://uat-billing-service-1004637461064.asia-northeast1.run.app
     ssr:
       - id: public
         worker_name: frontend-ssr-public-uat
@@ -118,7 +118,7 @@ spec:
     edge_gateway:
       defaults:
         primary_upstream: https://accounts-vps-uat.onwalk.net
-        fallback_upstream: https://accounts-service-uc.a.run.app
+        fallback_upstream: https://uat-accounts-1004637461064.asia-northeast1.run.app
         jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
         timeout_ms: '2500'
       boundaries:


### PR DESCRIPTION
## Outcome

Align the UAT serverless routing declaration with the currently deployed Cloud Run service URIs so the Edge Gateway can reach the intended Accounts, Content, and Billing backends.

## Issue

- N/A — follow-up to the UAT serverless chain diagnosis and successful deployment run [32017012356](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32017012356).

## Scope

- Updated the UAT serverless Cloud Run service URIs and Accounts fallback upstream.
- Kept canonical DNS names, traffic weights, hybrid/selfhost profiles, secrets, and deployment workflow behavior unchanged.

## Verification

- `git diff --check` — passed.
- Ruby YAML parse — passed.
- GitOps routing render plus `validate_cloudflare_boundaries.py` — passed; 9 boundaries validated.
- Public HTTPS probes against all three Cloud Run endpoints — reachable; root path returned expected 404 from Google Frontend.

## Risk / Security / Configuration

- Configuration-only UAT routing change; no credentials or tokens added.
- The companion platform automation PR will attach the declared Cloudflare custom domains and verify the browser CORS preflight chain.

## Rollback

Revert this PR to restore the previous UAT serverless upstream declarations.

## Related

- Companion [platform-ops-toolkit PR #398](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/398); merge this GitOps declaration before enabling the companion domain reconciliation workflow.
