### PR TITLE
fix: remove migration execution flags from topology

### DIFF
--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -55,3 +55,6 @@ jobs:
       # docker ps 上看不出任何异常。这一步把那个错误提前到 PR 阶段。
       - name: Verify every declared image resolves
         run: scripts/verify-images.sh
+
+      - name: Validate runtime topology declarations
+        run: scripts/validate-runtime-topologies.sh

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -110,10 +110,10 @@ file does not enable production traffic.
 - `selfhost` uses self-managed PostgreSQL;
 - `serverless` uses Supabase Cloud DB;
 - `primary` and `replica` identify the current writer and prepared standby by mode;
-- `migration.enabled` is `false` until an engine, network path, slot/publication policy, and
-  cutover runbook have been approved;
 - the reserved migration is asynchronous, bidirectional, single-writer, and capped at a
   60-second lag target with a required quiesce window;
+- execution is selected by the control-plane workflow `operation`; this declarative topology does
+  not contain an execution-enable flag.
 - connection strings, replication credentials, JWT secrets, Cloudflare tokens, and service
   account keys are never stored in GitOps.
 

--- a/scripts/validate-runtime-topologies.sh
+++ b/scripts/validate-runtime-topologies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v ruby >/dev/null 2>&1 || {
+  echo "Ruby is required to validate runtime topology declarations" >&2
+  exit 1
+}
+
+validated_count=0
+while IFS= read -r topology_file; do
+  ruby -ryaml -e '
+    document = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: false)
+    migration = document.dig("spec", "runtime", "data", "migration")
+    abort("#{ARGV.fetch(0)}: migration topology missing") unless migration.is_a?(Hash)
+    abort("#{ARGV.fetch(0)}: migration execution flag must be absent") if migration.key?("enabled")
+    abort("#{ARGV.fetch(0)}: migration strategy must remain async") unless migration["strategy"] == "async"
+    abort("#{ARGV.fetch(0)}: migration must remain single-writer") unless migration["single_writer"] == true
+    abort("#{ARGV.fetch(0)}: migration lag target must remain 60 seconds") unless migration["max_lag_seconds"] == 60
+    abort("#{ARGV.fetch(0)}: migration must require a quiesce window") unless migration["require_quiesce_for_cutover"] == true
+  ' "${topology_file}"
+  validated_count=$((validated_count + 1))
+done < <(find topology -path '*/runtime-topology.yaml' -type f -print | sort)
+
+if [[ "${validated_count}" -eq 0 ]]; then
+  echo "No runtime topology declarations found" >&2
+  exit 1
+fi
+
+echo "Validated ${validated_count} runtime topology declaration(s)"

--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/prod/selfhost/runtime-topology.yaml
+++ b/topology/prod/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/sit/selfhost/runtime-topology.yaml
+++ b/topology/sit/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/uat/hybrid/runtime-topology.yaml
+++ b/topology/uat/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/uat/selfhost/runtime-topology.yaml
+++ b/topology/uat/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60


### PR DESCRIPTION
## Outcome

Removes `spec.runtime.data.migration.enabled` from every runtime topology so GitOps declares migration constraints only; workflow `operation` remains the sole execution selector.

## Issue

- [Failed Serverless Orchestrator run 32076546185](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32076546185/job/95530893637)
- N/A — no separate issue was provided.

## Scope

- Remove the migration execution flag from all SIT, UAT, and PROD selfhost, serverless, and hybrid runtime topologies.
- Update the GitOps routing contract documentation to describe control-plane operation ownership.
- Add a repository validation script that requires migration constraints while rejecting a reintroduced execution flag.
- Do not change routing weights, primary/replica modes, service endpoints, DNS, secrets, or any deployment action.

## Verification

- `scripts/validate-runtime-topologies.sh` — passed; validated 9 runtime topology declarations.
- Parsed the PR workflow YAML with Ruby `YAML.safe_load` — passed.
- Verified no migration execution flag remains in topology, the routing contract document, or the validator script — passed.
- `git diff --check` — passed.
- PR CI — pending.

## Risk / Security / Configuration

- GitOps schema simplification only; migration safety constraints remain declarative: async strategy, single writer, 60-second lag target, and required quiesce window.
- No runtime deployment, migration, credential, DNS, Cloudflare, or Cloud Run change is performed by this PR.

## Rollback

Revert this PR together with the companion control-plane PR if the legacy execution-flag schema must be restored.

## Related

- Companion control-plane PR: [platform-ops-toolkit #399](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/399).
- Merge GitOps PR #161 before platform-ops-toolkit #399 so the deployed topology schema and validator contract stay aligned.
