### PR TITLE
feat: declare frontend router edge contract

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -89,7 +89,7 @@ into a monolithic Worker.
 | SSR workspace | `frontend-ssr-workspace-uat` | `/ai-workspace*`, `/editor*`, etc. | Independent lightweight Worker |
 | API auth | `edge-gateway-auth-uat` | `accounts-cloudflare-uat.onwalk.net/api/auth/*`, `/api/v1/auth/*` | Independent lightweight Worker |
 | API admin | `edge-gateway-admin-uat` | `accounts-cloudflare-uat.onwalk.net/api/admin/*` | Independent lightweight Worker |
-| API core | `edge-gateway-core-uat` | `accounts-cloudflare-uat.onwalk.net/api/*` fallback | Independent lightweight Worker |
+| Edge Gateway Router Core | `edge-gateway-core-uat` | `accounts-cloudflare-uat.onwalk.net` Custom Domain owner; `/api/*` fallback | Accounts entry owner and independent lightweight Worker |
 | Static assets | `ai-workspace-portal-uat` | `PAGES_ORIGIN` for `/_next/*`, `/static/*`, `/assets/*` | Pages deployment |
 
 The canonical names and complete route suffixes are declared in `spec.serverless.frontend_router`,
@@ -136,6 +136,8 @@ Consumers must read this GitOps declaration rather than repository-local environ
   static prefixes, and the five SSR Service Bindings;
 - `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
+  Its stable `id: core` has the display name **Edge Gateway Router Core** because it also owns the
+  Accounts Worker Custom Domain.
 
 All declaration changes require a GitOps PR to `main` before the platform orchestrator consumes
 them. Keep the three mode documents structurally aligned when changing shared domains, service

--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -28,9 +28,9 @@ DNS → VPS Full Stack → Console / Accounts / Content / Billing
                     → self-managed PostgreSQL
 
 Serverless mode
-DNS → Cloudflare Pages → SSR ×5 → edge-gateway ×3
-                      → Cloud Run: accounts / content-service / billing-service
-                      → Supabase Cloud DB
+DNS → Frontend Router → Pages (static) / SSR ×5 (dynamic) / edge-gateway ×3 (API)
+                                                       → Cloud Run: accounts / content-service / billing-service
+                                                       → Supabase Cloud DB (Cloud Run runtime only)
 
 Hybrid mode
 DNS → Cloudflare edge → edge-gateway
@@ -53,7 +53,7 @@ Each file is a complete `EdgeRoutingConfig`; `spec.runtime` is its single runtim
 The three UAT pre-configurations are intentionally explicit:
 
 - `selfhost`: DNS targets the VPS Full Stack, with selfhost as the database primary.
-- `serverless`: DNS targets Cloudflare Pages / edge-gateway, with Supabase as the database primary.
+- `serverless`: DNS targets the Frontend Router and Edge Gateway, with Supabase as the database primary.
 - `hybrid`: selfhost is the request-level primary and Cloud Run is the edge-gateway fallback.
 
 The active traffic choice is made by selecting the matching declaration in the orchestrator; the
@@ -74,24 +74,28 @@ failure, or a 5xx response. The edge-gateway failover is not a silent DNS mutati
 
 ## Cloudflare boundary split
 
-The Portal is deliberately built as five independent OpenNext SSR Workers, three independent
-edge-gateway Workers, and one Pages project. This split is required to keep each Cloudflare Worker
-artifact below the 3 MiB limit; the boundaries must not be recombined into a monolithic Worker.
+The Portal is deliberately built as one Frontend Router Worker, five independent OpenNext SSR
+Workers, three independent edge-gateway Workers, and one Pages project. This split is required to
+keep each Cloudflare Worker artifact below the 3 MiB limit; the boundaries must not be recombined
+into a monolithic Worker.
 
 | Boundary | Worker / Pages project | Routes | Deployment unit |
 | --- | --- | --- | --- |
-| SSR public pages | `frontend-ssr-public-uat` | `/*`, `/_edge/public/*` | Independent lightweight Worker |
+| Frontend Router | `frontend-router-uat` | `console-cloudflare-uat.onwalk.net/*` | Console Custom Domain owner; static/API/SSR dispatcher |
+| SSR public pages | `frontend-ssr-public-uat` | Router Service Binding fallback | Independent lightweight Worker |
 | SSR content pages | `frontend-ssr-content-uat` | `/blogs*`, `/docs*`, `/download*` | Independent lightweight Worker |
 | SSR identity pages | `frontend-ssr-auth-uat` | `/login*`, `/register*`, etc. | Independent lightweight Worker |
 | SSR console | `frontend-ssr-console-uat` | `/panel*`, `/dashboard*` | Independent lightweight Worker |
 | SSR workspace | `frontend-ssr-workspace-uat` | `/ai-workspace*`, `/editor*`, etc. | Independent lightweight Worker |
-| API auth | `edge-gateway-auth-uat` | `accounts-cloudflare-uat.onwalk.net/api/auth/*` | Independent lightweight Worker |
+| API auth | `edge-gateway-auth-uat` | `accounts-cloudflare-uat.onwalk.net/api/auth/*`, `/api/v1/auth/*` | Independent lightweight Worker |
 | API admin | `edge-gateway-admin-uat` | `accounts-cloudflare-uat.onwalk.net/api/admin/*` | Independent lightweight Worker |
 | API core | `edge-gateway-core-uat` | `accounts-cloudflare-uat.onwalk.net/api/*` fallback | Independent lightweight Worker |
-| Static assets | `ai-workspace-portal-uat` | `/static/*`, `/assets/*` | Pages deployment |
+| Static assets | `ai-workspace-portal-uat` | `PAGES_ORIGIN` for `/_next/*`, `/static/*`, `/assets/*` | Pages deployment |
 
-The canonical names and complete route suffixes are declared in `spec.serverless.ssr` and
-`spec.serverless.edge_gateway`; the table is a human-readable summary of that contract.
+The canonical names and complete route suffixes are declared in `spec.serverless.frontend_router`,
+`spec.serverless.ssr`, and `spec.serverless.edge_gateway`; the table is a human-readable summary
+of that contract. The canonical Console and Accounts DNS names remain the only user-facing entries;
+their `*-cloudflare-*` hosts are environment-specific Worker Custom Domain targets.
 
 The production naming contract follows the same shape:
 
@@ -110,8 +114,8 @@ file does not enable production traffic.
 - `selfhost` uses self-managed PostgreSQL;
 - `serverless` uses Supabase Cloud DB;
 - `primary` and `replica` identify the current writer and prepared standby by mode;
-- `migration.enabled` is `false` until an engine, network path, slot/publication policy, and
-  cutover runbook have been approved;
+- migration execution is selected only by the delivery workflow's `operation` input; the topology
+  retains strategy and safety constraints but does not contain an enable/disable action switch;
 - the reserved migration is asynchronous, bidirectional, single-writer, and capped at a
   60-second lag target with a required quiesce window;
 - connection strings, replication credentials, JWT secrets, Cloudflare tokens, and service
@@ -128,6 +132,8 @@ Consumers must read this GitOps declaration rather than repository-local environ
 - `spec.runtime` defines mode, routing, services, and data handover;
 - `spec.domains` defines the canonical `selfhost` and `serverless` CNAME targets;
 - `spec.cloudflare` defines the Pages project and zone;
+- `spec.serverless.frontend_router` defines the Console Worker Custom Domain, Pages/API origins,
+  static prefixes, and the five SSR Service Bindings;
 - `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
 

--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -131,5 +131,6 @@ spec:
           worker_name: edge-gateway-admin-prod
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-prod
           route: /api/*

--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/prod/selfhost/runtime-topology.yaml
+++ b/topology/prod/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/prod/selfhost/runtime-topology.yaml
+++ b/topology/prod/selfhost/runtime-topology.yaml
@@ -128,5 +128,6 @@ spec:
           worker_name: edge-gateway-admin-prod
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-prod
           route: /api/*

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60
@@ -75,6 +74,21 @@ spec:
   serverless:
     console_host: console-cloudflare-prod.svc.plus
     accounts_host: accounts-cloudflare-prod.svc.plus
+    frontend_router:
+      worker_name: frontend-router-prod
+      host: console-cloudflare-prod.svc.plus
+      pages_origin: https://ai-workspace-portal-prod.pages.dev
+      api_origin: https://accounts-cloudflare-prod.svc.plus
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        auth: frontend-ssr-auth-prod
+        content: frontend-ssr-content-prod
+        console: frontend-ssr-console-prod
+        workspace: frontend-ssr-workspace-prod
+        public: frontend-ssr-public-prod
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -124,10 +138,14 @@ spec:
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-prod
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-prod
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           worker_name: edge-gateway-core-prod
-          route: /api/*
+          routes:
+            - /api/*

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -146,6 +146,7 @@ spec:
           routes:
             - /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-prod
           routes:
             - /api/*

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -131,5 +131,6 @@ spec:
           worker_name: edge-gateway-admin-sit
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-sit
           route: /api/*

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/sit/selfhost/runtime-topology.yaml
+++ b/topology/sit/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/sit/selfhost/runtime-topology.yaml
+++ b/topology/sit/selfhost/runtime-topology.yaml
@@ -128,5 +128,6 @@ spec:
           worker_name: edge-gateway-admin-sit
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-sit
           route: /api/*

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -146,6 +146,7 @@ spec:
           routes:
             - /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-sit
           routes:
             - /api/*

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60
@@ -75,6 +74,21 @@ spec:
   serverless:
     console_host: console-cloudflare-sit.onwalk.net
     accounts_host: accounts-cloudflare-sit.onwalk.net
+    frontend_router:
+      worker_name: frontend-router-sit
+      host: console-cloudflare-sit.onwalk.net
+      pages_origin: https://ai-workspace-portal-sit.pages.dev
+      api_origin: https://accounts-cloudflare-sit.onwalk.net
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        auth: frontend-ssr-auth-sit
+        content: frontend-ssr-content-sit
+        console: frontend-ssr-console-sit
+        workspace: frontend-ssr-workspace-sit
+        public: frontend-ssr-public-sit
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -124,10 +138,14 @@ spec:
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-sit
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-sit
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           worker_name: edge-gateway-core-sit
-          route: /api/*
+          routes:
+            - /api/*

--- a/topology/uat/hybrid/runtime-topology.yaml
+++ b/topology/uat/hybrid/runtime-topology.yaml
@@ -131,5 +131,6 @@ spec:
           worker_name: edge-gateway-admin-uat
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-uat
           route: /api/*

--- a/topology/uat/hybrid/runtime-topology.yaml
+++ b/topology/uat/hybrid/runtime-topology.yaml
@@ -43,7 +43,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/uat/selfhost/runtime-topology.yaml
+++ b/topology/uat/selfhost/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60

--- a/topology/uat/selfhost/runtime-topology.yaml
+++ b/topology/uat/selfhost/runtime-topology.yaml
@@ -128,5 +128,6 @@ spec:
           worker_name: edge-gateway-admin-uat
           route: /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-uat
           route: /api/*

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -40,7 +40,6 @@ spec:
         selfhost: self-managed-postgresql
         serverless: supabase
       migration:
-        enabled: false
         strategy: async
         single_writer: true
         max_lag_seconds: 60
@@ -75,6 +74,21 @@ spec:
   serverless:
     console_host: console-cloudflare-uat.onwalk.net
     accounts_host: accounts-cloudflare-uat.onwalk.net
+    frontend_router:
+      worker_name: frontend-router-uat
+      host: console-cloudflare-uat.onwalk.net
+      pages_origin: https://ai-workspace-portal-uat.pages.dev
+      api_origin: https://accounts-cloudflare-uat.onwalk.net
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        auth: frontend-ssr-auth-uat
+        content: frontend-ssr-content-uat
+        console: frontend-ssr-console-uat
+        workspace: frontend-ssr-workspace-uat
+        public: frontend-ssr-public-uat
     cloud_run:
       accounts: https://uat-accounts-1004637461064.asia-northeast1.run.app
       content_service: https://uat-content-service-1004637461064.asia-northeast1.run.app
@@ -124,10 +138,14 @@ spec:
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-uat
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-uat
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           worker_name: edge-gateway-core-uat
-          route: /api/*
+          routes:
+            - /api/*

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -146,6 +146,7 @@ spec:
           routes:
             - /api/admin/*
         - id: core
+          display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-uat
           routes:
             - /api/*


### PR DESCRIPTION
## Outcome

GitOps now centrally declares the Console Frontend Router and the Accounts Edge Gateway contract for SIT, UAT, and PROD. DNS remains limited to the two user-visible canonical hosts.

## Context

The target topology is `console → Frontend Router → Pages/SSR/API` and `accounts → Edge Gateway → Cloud Run → Supabase`. Pages is an origin, not the Console custom-domain owner. Migration execution must be controlled by workflow `operation`, not by a topology enable flag.

## Changes

- Add `spec.serverless.frontend_router` with its Worker name, Console target host, Pages/API origins, static prefixes, and five SSR Service Bindings.
- Replace Edge Gateway's singular `route` with declarative `routes[]`, including `/api/v1/auth/*`.
- Remove `spec.runtime.data.migration.enabled` from all nine runtime topologies.
- Update the serverless routing document to define domain ownership and the Cloud Run-only Supabase DB URI boundary.

## Verification

- Parsed all nine topology YAML files with safe YAML loading.
- Rendered and validated SIT, UAT, and PROD serverless declarations against the new Cloudflare boundary validator; each reports 10 boundaries.
- `git diff --check` passed.

## Dependencies and rollout

- Requires https://github.com/ai-workspace-services/edge-gateway/pull/11 before `routes[]` is consumed at deployment time.
- Requires the platform-orchestrator PR that deploys `frontend-router` and performs the guarded custom-domain cutover.
- Do not merge and run a deployment until an immutable `daily-build-*` tag exists in the frontend-router repository.
- No DNS, Pages Custom Domain, Worker Custom Domain, Cloud Run URL, or database credential is changed by this PR.

## Links

- Architecture/docs: https://github.com/ai-workspace-services/knowledge/pull/37
- Frontend Router: https://github.com/ai-workspace-services/frontend-router/pull/1
- Edge Gateway compatibility: https://github.com/ai-workspace-services/edge-gateway/pull/11
