### PR TITLE
feat: declare mode-qualified public service endpoints

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -61,12 +61,28 @@ pipeline must never validate or deploy against a different mode file.
 
 ## Canonical DNS contract
 
-Canonical hostnames remain stable; only their CNAME targets change:
+Canonical hostnames remain stable; only their CNAME targets change. In addition, every complete
+runtime profile declares five mode-qualified public service entrances using the form
+`<service>-<mode>-<environment>.<base-domain>`:
 
-| Canonical hostname | VPS CNAME | Serverless CNAME |
+| Canonical hostname | Selfhost CNAME | Serverless CNAME |
 | --- | --- | --- |
-| `console-uat.onwalk.net` | `console-vps-uat.onwalk.net` | `console-cloudflare-uat.onwalk.net` |
-| `accounts-uat.onwalk.net` | `accounts-vps-uat.onwalk.net` | `accounts-cloudflare-uat.onwalk.net` |
+| `console-uat.onwalk.net` | `console-selfhost-uat.onwalk.net` | `console-serverless-uat.onwalk.net` |
+| `accounts-uat.onwalk.net` | `accounts-selfhost-uat.onwalk.net` | `accounts-serverless-uat.onwalk.net` |
+
+| Service | Access contract | Serverless UAT entrance |
+| --- | --- | --- |
+| Console | public | `console-serverless-uat.onwalk.net` |
+| Accounts | authenticated | `accounts-serverless-uat.onwalk.net` |
+| Billing | authenticated | `billing-serverless-uat.onwalk.net` |
+| PostgreSQL | authenticated | `postgresql-serverless-uat.onwalk.net` |
+| Agent-Proxy | public UUID with internal validation | `agent-proxy-serverless-uat.onwalk.net` |
+
+The same five entries are declared for `selfhost`, `serverless`, and `hybrid`; only the mode
+segment changes. The complete declaration is `spec.public_endpoints`. The Serverless workflow
+actively reconciles and verifies Console, Accounts, and Billing. PostgreSQL and Agent-Proxy keep
+their provider-owned authenticated/UUID validation paths until their Serverless providers expose
+an equivalent public adapter.
 
 DNS is the top-level switch for `selfhost` and `serverless`. `hybrid` adds request-level failover at
 edge-gateway: selfhost is tried first for 2500 ms, then Cloud Run is retried on timeout, connection
@@ -81,28 +97,28 @@ into a monolithic Worker.
 
 | Boundary | Worker / Pages project | Routes | Deployment unit |
 | --- | --- | --- | --- |
-| Frontend Router | `frontend-router-uat` | `console-cloudflare-uat.onwalk.net/*` | Console Custom Domain owner; static/API/SSR dispatcher |
+| Frontend Router | `frontend-router-uat` | `console-serverless-uat.onwalk.net/*` | Console Custom Domain owner; static/API/SSR dispatcher |
 | SSR public pages | `frontend-ssr-public-uat` | Router Service Binding fallback | Independent lightweight Worker |
 | SSR content pages | `frontend-ssr-content-uat` | `/blogs*`, `/docs*`, `/download*` | Independent lightweight Worker |
 | SSR identity pages | `frontend-ssr-auth-uat` | `/login*`, `/register*`, etc. | Independent lightweight Worker |
 | SSR console | `frontend-ssr-console-uat` | `/panel*`, `/dashboard*` | Independent lightweight Worker |
 | SSR workspace | `frontend-ssr-workspace-uat` | `/ai-workspace*`, `/editor*`, etc. | Independent lightweight Worker |
-| API auth | `edge-gateway-auth-uat` | `accounts-cloudflare-uat.onwalk.net/api/auth/*`, `/api/v1/auth/*` | Independent lightweight Worker |
-| API admin | `edge-gateway-admin-uat` | `accounts-cloudflare-uat.onwalk.net/api/admin/*` | Independent lightweight Worker |
-| Edge Gateway Router Core | `edge-gateway-core-uat` | `accounts-cloudflare-uat.onwalk.net` Custom Domain owner; `/api/*` fallback | Accounts entry owner and independent lightweight Worker |
+| API auth | `edge-gateway-auth-uat` | `accounts-serverless-uat.onwalk.net/api/auth/*`, `/api/v1/auth/*` | Independent lightweight Worker |
+| API admin | `edge-gateway-admin-uat` | `accounts-serverless-uat.onwalk.net/api/admin/*` | Independent lightweight Worker |
+| Edge Gateway Router Core | `edge-gateway-core-uat` | `accounts-serverless-uat.onwalk.net` Custom Domain owner; `/api/*` fallback | Accounts entry owner and independent lightweight Worker |
 | Static assets | `ai-workspace-portal-uat` | `PAGES_ORIGIN` for `/_next/*`, `/static/*`, `/assets/*` | Pages deployment |
 
 The canonical names and complete route suffixes are declared in `spec.serverless.frontend_router`,
 `spec.serverless.ssr`, and `spec.serverless.edge_gateway`; the table is a human-readable summary
-of that contract. The canonical Console and Accounts DNS names remain the only user-facing entries;
-their `*-cloudflare-*` hosts are environment-specific Worker Custom Domain targets.
+of that contract. The canonical Console and Accounts DNS names remain stable traffic-switch aliases;
+the five mode-qualified hosts in `spec.public_endpoints` are the service-specific public entrances.
 
 The production naming contract follows the same shape:
 
-| Canonical hostname | VPS CNAME | Serverless CNAME |
+| Canonical hostname | Selfhost CNAME | Serverless CNAME |
 | --- | --- | --- |
-| `console.svc.plus` | `console-vps-prod.svc.plus` | `console-cloudflare-prod.svc.plus` |
-| `accounts.svc.plus` | `accounts-vps-prod.svc.plus` | `accounts-cloudflare-prod.svc.plus` |
+| `console.svc.plus` | `console-selfhost-prod.svc.plus` | `console-serverless-prod.svc.plus` |
+| `accounts.svc.plus` | `accounts-selfhost-prod.svc.plus` | `accounts-serverless-prod.svc.plus` |
 
 Production must be introduced through its own environment-scoped declaration and PR; the UAT
 file does not enable production traffic.
@@ -132,7 +148,9 @@ without overwriting or deleting migration checkpoints.
 Consumers must read this GitOps declaration rather than repository-local environment constants:
 
 - `spec.runtime` defines mode, routing, services, and data handover;
-- `spec.domains` defines the canonical `selfhost` and `serverless` CNAME targets;
+- `spec.domains` defines the canonical Console/Accounts aliases;
+- `spec.public_endpoints` defines the five mode-qualified public service entrances and access
+  contracts (`public`, `authenticated`, `public_uuid`);
 - `spec.cloudflare` defines the Pages project and zone;
 - `spec.serverless.frontend_router` defines the Console Worker Custom Domain, Pages/API origins,
   static prefixes, and the five SSR Service Bindings;

--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console.svc.plus: console-cloudflare-prod.svc.plus
-          accounts.svc.plus: accounts-cloudflare-prod.svc.plus
+          console.svc.plus: console-hybrid-prod.svc.plus
+          accounts.svc.plus: accounts-hybrid-prod.svc.plus
       load-balancer:
         strategy: request-failover
         hybrid:
@@ -57,11 +57,27 @@ spec:
             target: selfhost
   domains:
     console.svc.plus:
-      selfhost: console-vps-prod.svc.plus
-      serverless: console-cloudflare-prod.svc.plus
+      selfhost: console-selfhost-prod.svc.plus
+      serverless: console-serverless-prod.svc.plus
     accounts.svc.plus:
-      selfhost: accounts-vps-prod.svc.plus
-      serverless: accounts-cloudflare-prod.svc.plus
+      selfhost: accounts-selfhost-prod.svc.plus
+      serverless: accounts-serverless-prod.svc.plus
+  public_endpoints:
+    console:
+      host: console-hybrid-prod.svc.plus
+      access: public
+    accounts:
+      host: accounts-hybrid-prod.svc.plus
+      access: authenticated
+    billing:
+      host: billing-hybrid-prod.svc.plus
+      access: authenticated
+    postgresql:
+      host: postgresql-hybrid-prod.svc.plus
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-hybrid-prod.svc.plus
+      access: public_uuid
   cloudflare:
     zone_name: svc.plus
     pages_project: ai-workspace-portal-prod
@@ -75,8 +91,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-prod.svc.plus
-    accounts_host: accounts-cloudflare-prod.svc.plus
+    console_host: console-serverless-prod.svc.plus
+    accounts_host: accounts-serverless-prod.svc.plus
+    billing_host: billing-serverless-prod.svc.plus
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -119,9 +136,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-prod.svc.plus
+        primary_upstream: https://accounts-selfhost-prod.svc.plus
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        jwt_issuer: https://accounts-serverless-prod.svc.plus
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/prod/selfhost/runtime-topology.yaml
+++ b/topology/prod/selfhost/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console.svc.plus: console-vps-prod.svc.plus
-          accounts.svc.plus: accounts-vps-prod.svc.plus
+          console.svc.plus: console-selfhost-prod.svc.plus
+          accounts.svc.plus: accounts-selfhost-prod.svc.plus
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console.svc.plus:
-      selfhost: console-vps-prod.svc.plus
-      serverless: console-cloudflare-prod.svc.plus
+      selfhost: console-selfhost-prod.svc.plus
+      serverless: console-serverless-prod.svc.plus
     accounts.svc.plus:
-      selfhost: accounts-vps-prod.svc.plus
-      serverless: accounts-cloudflare-prod.svc.plus
+      selfhost: accounts-selfhost-prod.svc.plus
+      serverless: accounts-serverless-prod.svc.plus
+  public_endpoints:
+    console:
+      host: console-selfhost-prod.svc.plus
+      access: public
+    accounts:
+      host: accounts-selfhost-prod.svc.plus
+      access: authenticated
+    billing:
+      host: billing-selfhost-prod.svc.plus
+      access: authenticated
+    postgresql:
+      host: postgresql-selfhost-prod.svc.plus
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-selfhost-prod.svc.plus
+      access: public_uuid
   cloudflare:
     zone_name: svc.plus
     pages_project: ai-workspace-portal-prod
@@ -72,8 +88,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-prod.svc.plus
-    accounts_host: accounts-cloudflare-prod.svc.plus
+    console_host: console-serverless-prod.svc.plus
+    accounts_host: accounts-serverless-prod.svc.plus
+    billing_host: billing-serverless-prod.svc.plus
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -116,9 +133,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-prod.svc.plus
+        primary_upstream: https://accounts-selfhost-prod.svc.plus
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        jwt_issuer: https://accounts-serverless-prod.svc.plus
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console.svc.plus: console-cloudflare-prod.svc.plus
-          accounts.svc.plus: accounts-cloudflare-prod.svc.plus
+          console.svc.plus: console-serverless-prod.svc.plus
+          accounts.svc.plus: accounts-serverless-prod.svc.plus
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console.svc.plus:
-      selfhost: console-vps-prod.svc.plus
-      serverless: console-cloudflare-prod.svc.plus
+      selfhost: console-selfhost-prod.svc.plus
+      serverless: console-serverless-prod.svc.plus
     accounts.svc.plus:
-      selfhost: accounts-vps-prod.svc.plus
-      serverless: accounts-cloudflare-prod.svc.plus
+      selfhost: accounts-selfhost-prod.svc.plus
+      serverless: accounts-serverless-prod.svc.plus
+  public_endpoints:
+    console:
+      host: console-serverless-prod.svc.plus
+      access: public
+    accounts:
+      host: accounts-serverless-prod.svc.plus
+      access: authenticated
+    billing:
+      host: billing-serverless-prod.svc.plus
+      access: authenticated
+    postgresql:
+      host: postgresql-serverless-prod.svc.plus
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-serverless-prod.svc.plus
+      access: public_uuid
   cloudflare:
     zone_name: svc.plus
     pages_project: ai-workspace-portal-prod
@@ -72,13 +88,14 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-prod.svc.plus
-    accounts_host: accounts-cloudflare-prod.svc.plus
+    console_host: console-serverless-prod.svc.plus
+    accounts_host: accounts-serverless-prod.svc.plus
+    billing_host: billing-serverless-prod.svc.plus
     frontend_router:
       worker_name: frontend-router-prod
-      host: console-cloudflare-prod.svc.plus
+      host: console-serverless-prod.svc.plus
       pages_origin: https://ai-workspace-portal-prod.pages.dev
-      api_origin: https://accounts-cloudflare-prod.svc.plus
+      api_origin: https://accounts-serverless-prod.svc.plus
       static_prefixes:
         - /_next/*
         - /static/*
@@ -131,9 +148,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-prod.svc.plus
+        primary_upstream: https://accounts-selfhost-prod.svc.plus
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-prod.svc.plus
+        jwt_issuer: https://accounts-serverless-prod.svc.plus
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-sit.onwalk.net: console-cloudflare-sit.onwalk.net
-          accounts-sit.onwalk.net: accounts-cloudflare-sit.onwalk.net
+          console-sit.onwalk.net: console-hybrid-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-hybrid-sit.onwalk.net
       load-balancer:
         strategy: request-failover
         hybrid:
@@ -57,11 +57,27 @@ spec:
             target: selfhost
   domains:
     console-sit.onwalk.net:
-      selfhost: console-vps-sit.onwalk.net
-      serverless: console-cloudflare-sit.onwalk.net
+      selfhost: console-selfhost-sit.onwalk.net
+      serverless: console-serverless-sit.onwalk.net
     accounts-sit.onwalk.net:
-      selfhost: accounts-vps-sit.onwalk.net
-      serverless: accounts-cloudflare-sit.onwalk.net
+      selfhost: accounts-selfhost-sit.onwalk.net
+      serverless: accounts-serverless-sit.onwalk.net
+  public_endpoints:
+    console:
+      host: console-hybrid-sit.onwalk.net
+      access: public
+    accounts:
+      host: accounts-hybrid-sit.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-hybrid-sit.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-hybrid-sit.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-hybrid-sit.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-sit
@@ -75,8 +91,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-sit.onwalk.net
-    accounts_host: accounts-cloudflare-sit.onwalk.net
+    console_host: console-serverless-sit.onwalk.net
+    accounts_host: accounts-serverless-sit.onwalk.net
+    billing_host: billing-serverless-sit.onwalk.net
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -119,9 +136,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-sit.onwalk.net
+        primary_upstream: https://accounts-selfhost-sit.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        jwt_issuer: https://accounts-serverless-sit.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/sit/selfhost/runtime-topology.yaml
+++ b/topology/sit/selfhost/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-sit.onwalk.net: console-vps-sit.onwalk.net
-          accounts-sit.onwalk.net: accounts-vps-sit.onwalk.net
+          console-sit.onwalk.net: console-selfhost-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-selfhost-sit.onwalk.net
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console-sit.onwalk.net:
-      selfhost: console-vps-sit.onwalk.net
-      serverless: console-cloudflare-sit.onwalk.net
+      selfhost: console-selfhost-sit.onwalk.net
+      serverless: console-serverless-sit.onwalk.net
     accounts-sit.onwalk.net:
-      selfhost: accounts-vps-sit.onwalk.net
-      serverless: accounts-cloudflare-sit.onwalk.net
+      selfhost: accounts-selfhost-sit.onwalk.net
+      serverless: accounts-serverless-sit.onwalk.net
+  public_endpoints:
+    console:
+      host: console-selfhost-sit.onwalk.net
+      access: public
+    accounts:
+      host: accounts-selfhost-sit.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-selfhost-sit.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-selfhost-sit.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-selfhost-sit.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-sit
@@ -72,8 +88,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-sit.onwalk.net
-    accounts_host: accounts-cloudflare-sit.onwalk.net
+    console_host: console-serverless-sit.onwalk.net
+    accounts_host: accounts-serverless-sit.onwalk.net
+    billing_host: billing-serverless-sit.onwalk.net
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -116,9 +133,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-sit.onwalk.net
+        primary_upstream: https://accounts-selfhost-sit.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        jwt_issuer: https://accounts-serverless-sit.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-sit.onwalk.net: console-cloudflare-sit.onwalk.net
-          accounts-sit.onwalk.net: accounts-cloudflare-sit.onwalk.net
+          console-sit.onwalk.net: console-serverless-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-serverless-sit.onwalk.net
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console-sit.onwalk.net:
-      selfhost: console-vps-sit.onwalk.net
-      serverless: console-cloudflare-sit.onwalk.net
+      selfhost: console-selfhost-sit.onwalk.net
+      serverless: console-serverless-sit.onwalk.net
     accounts-sit.onwalk.net:
-      selfhost: accounts-vps-sit.onwalk.net
-      serverless: accounts-cloudflare-sit.onwalk.net
+      selfhost: accounts-selfhost-sit.onwalk.net
+      serverless: accounts-serverless-sit.onwalk.net
+  public_endpoints:
+    console:
+      host: console-serverless-sit.onwalk.net
+      access: public
+    accounts:
+      host: accounts-serverless-sit.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-serverless-sit.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-serverless-sit.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-serverless-sit.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-sit
@@ -72,13 +88,14 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-sit.onwalk.net
-    accounts_host: accounts-cloudflare-sit.onwalk.net
+    console_host: console-serverless-sit.onwalk.net
+    accounts_host: accounts-serverless-sit.onwalk.net
+    billing_host: billing-serverless-sit.onwalk.net
     frontend_router:
       worker_name: frontend-router-sit
-      host: console-cloudflare-sit.onwalk.net
+      host: console-serverless-sit.onwalk.net
       pages_origin: https://ai-workspace-portal-sit.pages.dev
-      api_origin: https://accounts-cloudflare-sit.onwalk.net
+      api_origin: https://accounts-serverless-sit.onwalk.net
       static_prefixes:
         - /_next/*
         - /static/*
@@ -131,9 +148,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-sit.onwalk.net
+        primary_upstream: https://accounts-selfhost-sit.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-sit.onwalk.net
+        jwt_issuer: https://accounts-serverless-sit.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/uat/hybrid/runtime-topology.yaml
+++ b/topology/uat/hybrid/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
-          accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
+          console-uat.onwalk.net: console-hybrid-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-hybrid-uat.onwalk.net
       load-balancer:
         strategy: request-failover
         hybrid:
@@ -57,11 +57,27 @@ spec:
             target: selfhost
   domains:
     console-uat.onwalk.net:
-      selfhost: console-vps-uat.onwalk.net
-      serverless: console-cloudflare-uat.onwalk.net
+      selfhost: console-selfhost-uat.onwalk.net
+      serverless: console-serverless-uat.onwalk.net
     accounts-uat.onwalk.net:
-      selfhost: accounts-vps-uat.onwalk.net
-      serverless: accounts-cloudflare-uat.onwalk.net
+      selfhost: accounts-selfhost-uat.onwalk.net
+      serverless: accounts-serverless-uat.onwalk.net
+  public_endpoints:
+    console:
+      host: console-hybrid-uat.onwalk.net
+      access: public
+    accounts:
+      host: accounts-hybrid-uat.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-hybrid-uat.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-hybrid-uat.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-hybrid-uat.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
@@ -75,8 +91,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-uat.onwalk.net
-    accounts_host: accounts-cloudflare-uat.onwalk.net
+    console_host: console-serverless-uat.onwalk.net
+    accounts_host: accounts-serverless-uat.onwalk.net
+    billing_host: billing-serverless-uat.onwalk.net
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -119,9 +136,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-uat.onwalk.net
+        primary_upstream: https://accounts-selfhost-uat.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        jwt_issuer: https://accounts-serverless-uat.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/uat/selfhost/runtime-topology.yaml
+++ b/topology/uat/selfhost/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-uat.onwalk.net: console-vps-uat.onwalk.net
-          accounts-uat.onwalk.net: accounts-vps-uat.onwalk.net
+          console-uat.onwalk.net: console-selfhost-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-selfhost-uat.onwalk.net
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console-uat.onwalk.net:
-      selfhost: console-vps-uat.onwalk.net
-      serverless: console-cloudflare-uat.onwalk.net
+      selfhost: console-selfhost-uat.onwalk.net
+      serverless: console-serverless-uat.onwalk.net
     accounts-uat.onwalk.net:
-      selfhost: accounts-vps-uat.onwalk.net
-      serverless: accounts-cloudflare-uat.onwalk.net
+      selfhost: accounts-selfhost-uat.onwalk.net
+      serverless: accounts-serverless-uat.onwalk.net
+  public_endpoints:
+    console:
+      host: console-selfhost-uat.onwalk.net
+      access: public
+    accounts:
+      host: accounts-selfhost-uat.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-selfhost-uat.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-selfhost-uat.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-selfhost-uat.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
@@ -72,8 +88,9 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-uat.onwalk.net
-    accounts_host: accounts-cloudflare-uat.onwalk.net
+    console_host: console-serverless-uat.onwalk.net
+    accounts_host: accounts-serverless-uat.onwalk.net
+    billing_host: billing-serverless-uat.onwalk.net
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -116,9 +133,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-uat.onwalk.net
+        primary_upstream: https://accounts-selfhost-uat.onwalk.net
         fallback_upstream: https://accounts-service-uc.a.run.app
-        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        jwt_issuer: https://accounts-serverless-uat.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -13,8 +13,8 @@ spec:
         control_plane: cloudflare-dns
         ttl_seconds: 60
         canonical_records:
-          console-uat.onwalk.net: console-cloudflare-uat.onwalk.net
-          accounts-uat.onwalk.net: accounts-cloudflare-uat.onwalk.net
+          console-uat.onwalk.net: console-serverless-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-serverless-uat.onwalk.net
       load-balancer:
         strategy: dns-only
       weight:
@@ -54,11 +54,27 @@ spec:
             target: selfhost
   domains:
     console-uat.onwalk.net:
-      selfhost: console-vps-uat.onwalk.net
-      serverless: console-cloudflare-uat.onwalk.net
+      selfhost: console-selfhost-uat.onwalk.net
+      serverless: console-serverless-uat.onwalk.net
     accounts-uat.onwalk.net:
-      selfhost: accounts-vps-uat.onwalk.net
-      serverless: accounts-cloudflare-uat.onwalk.net
+      selfhost: accounts-selfhost-uat.onwalk.net
+      serverless: accounts-serverless-uat.onwalk.net
+  public_endpoints:
+    console:
+      host: console-serverless-uat.onwalk.net
+      access: public
+    accounts:
+      host: accounts-serverless-uat.onwalk.net
+      access: authenticated
+    billing:
+      host: billing-serverless-uat.onwalk.net
+      access: authenticated
+    postgresql:
+      host: postgresql-serverless-uat.onwalk.net
+      access: authenticated
+    agent-proxy:
+      host: agent-proxy-serverless-uat.onwalk.net
+      access: public_uuid
   cloudflare:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
@@ -72,13 +88,14 @@ spec:
       - billing
     database: self-managed-postgresql
   serverless:
-    console_host: console-cloudflare-uat.onwalk.net
-    accounts_host: accounts-cloudflare-uat.onwalk.net
+    console_host: console-serverless-uat.onwalk.net
+    accounts_host: accounts-serverless-uat.onwalk.net
+    billing_host: billing-serverless-uat.onwalk.net
     frontend_router:
       worker_name: frontend-router-uat
-      host: console-cloudflare-uat.onwalk.net
+      host: console-serverless-uat.onwalk.net
       pages_origin: https://ai-workspace-portal-uat.pages.dev
-      api_origin: https://accounts-cloudflare-uat.onwalk.net
+      api_origin: https://accounts-serverless-uat.onwalk.net
       static_prefixes:
         - /_next/*
         - /static/*
@@ -131,9 +148,9 @@ spec:
           - /_edge/workspace/*
     edge_gateway:
       defaults:
-        primary_upstream: https://accounts-vps-uat.onwalk.net
+        primary_upstream: https://accounts-selfhost-uat.onwalk.net
         fallback_upstream: https://uat-accounts-1004637461064.asia-northeast1.run.app
-        jwt_issuer: https://accounts-cloudflare-uat.onwalk.net
+        jwt_issuer: https://accounts-serverless-uat.onwalk.net
         timeout_ms: '2500'
       boundaries:
         - id: auth


### PR DESCRIPTION
## Outcome

GitOps now declares the five public service entrances for every deployment mode and environment using `<service>-<mode>-<environment>.<base-domain>`. Console, Accounts, Billing, PostgreSQL, and Agent-Proxy access semantics are explicit and consistent.

## Issue

- N/A — follow-up to the unified service-entry and Serverless Billing domain work requested in the deployment routing task.

## Scope

- Added `spec.public_endpoints` to all `prod`, `sit`, and `uat` `serverless`, `selfhost`, and `hybrid` topology profiles.
- Standardized Console/Accounts canonical targets and Serverless Worker host names to the mode-qualified contract.
- Added the Serverless Billing host declaration and documented which entries are actively reconciled by the current Serverless workflow.
- Intentionally did not add fake Cloudflare bindings for PostgreSQL or Agent-Proxy; their provider-owned authenticated/UUID paths remain declared until an equivalent adapter exists.

## Verification

- Ruby YAML parse for all nine topology declarations — passed.
- Serverless boundary validator for `sit`, `uat`, and `prod` — passed (`10 boundaries` each).
- Selfhost contract validator for `sit`, `uat`, and `prod` — passed in the companion platform worktree.
- `git diff --check` — passed.
- Platform workflow CI is not run from this repository; the companion platform PR adds the consumer/readiness changes.

## Risk / Security / Configuration

- This changes declared DNS targets and host naming; deployment consumers must merge the companion platform PR before applying the profiles.
- Access semantics are metadata only; credentials remain in Vault and no secrets are added.

## Rollback

Revert this PR and the companion platform PR together, then rerun the selected mode's validation before any DNS cutover.

## Related

- Companion [platform PR #409](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/409); merge the declaration before consuming it in the orchestrator.
- Base topology source: `ai-workspace-infra/gitops` `main`.
