### PR TITLE
fix: use internal Accounts URL for UAT Console

### DIFF
--- a/compose/web-saas/.env.uat
+++ b/compose/web-saas/.env.uat
@@ -65,8 +65,9 @@ STUNNEL_SERVER_IMAGE=ghcr.io/ai-workspace-infra/stunnel-server:sha-7759f4513e171
 STUNNEL_CLIENT_IMAGE=ghcr.io/ai-workspace-infra/stunnel-client:sha-7759f4513e1710e86332795b611507bbed37ea39
 
 # 部署环境。console 的 runtime-loader 以它决定连哪一套服务端点。
+# 服务端 BFF 走 compose 网络内的 Accounts；浏览器端仍走公共 HTTPS 入口。
 DEPLOY_ENV=uat
-ACCOUNT_SERVICE_URL=https://accounts-uat.onwalk.net
+ACCOUNT_SERVICE_URL=http://accounts:8080
 NEXT_PUBLIC_ACCOUNT_SERVICE_URL=https://accounts-uat.onwalk.net
 # Accounts 以反向代理传入的租户主域解析 XWorkmate 同步请求。该值必须与
 # web-saas Caddyfile 的 X-Forwarded-Host 保持一致；禁止在服务代码中回退到


### PR DESCRIPTION
## Outcome

Route UAT Console server-side Accounts calls over the Docker compose network while keeping browser-side Accounts calls on the public HTTPS endpoint.

## Issue

- [Selfhost Orchestrator run 32134309543](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32134309543)
- [Console public endpoint failure](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32134309543/job/95707149526)

## Scope

- Set UAT `ACCOUNT_SERVICE_URL` to `http://accounts:8080`.
- Keep `NEXT_PUBLIC_ACCOUNT_SERVICE_URL` as `https://accounts-uat.onwalk.net`.
- Change no image tag, database setting, DNS record, or secret.

## Verification

- Explicit `.env.uat` URL assertions — passed.
- `git diff --check` — passed.
- CI — not yet run; it will start from this PR.

## Risk / Security / Configuration

- Changes only the Console Accounts endpoint configuration for UAT.
- The internal URL stays on the existing compose network; browser traffic remains HTTPS through Caddy.

## Rollback

Revert commit `61c01fa` or revert this PR to restore the previous endpoint values.

## Related

- Companion ingress PR: [playbooks#373](https://github.com/ai-workspace-infra/playbooks/pull/373)
- Companion orchestration PR: [platform-ops-toolkit#417](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/417)
- Merge order: merge after playbooks#373 so the public alias ingress is present; merge platform-ops-toolkit#417 before the next migration run.
- [Original failed run](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32134309543)
