### PR TITLE
feat: declare serverless billing origin aliases

### DIFF
--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -91,6 +91,7 @@ spec:
     console_host: console-serverless-prod.svc.plus
     accounts_host: accounts-serverless-prod.svc.plus
     billing_host: billing-serverless-prod.svc.plus
+    billing_origin_host: billing-origin-serverless-prod.svc.plus
     frontend_router:
       worker_name: frontend-router-prod
       host: console-serverless-prod.svc.plus

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -91,6 +91,7 @@ spec:
     console_host: console-serverless-sit.onwalk.net
     accounts_host: accounts-serverless-sit.onwalk.net
     billing_host: billing-serverless-sit.onwalk.net
+    billing_origin_host: billing-origin-serverless-sit.onwalk.net
     frontend_router:
       worker_name: frontend-router-sit
       host: console-serverless-sit.onwalk.net

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -91,6 +91,7 @@ spec:
     console_host: console-serverless-uat.onwalk.net
     accounts_host: accounts-serverless-uat.onwalk.net
     billing_host: billing-serverless-uat.onwalk.net
+    billing_origin_host: billing-origin-serverless-uat.onwalk.net
     frontend_router:
       worker_name: frontend-router-uat
       host: console-serverless-uat.onwalk.net


### PR DESCRIPTION
## Outcome

Declare a deterministic, same-zone DNS-only Billing origin alias for every serverless environment so Cloudflare Origin Rules can override the origin without using Cloud Run Preview domain mapping.

## Issue

- [Serverless Orchestrator failure job](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32198428682/job/95909479148)
- Cloudflare Origin Rules `PUT` returned HTTP 400 when the native `run.app` hostname was used as the origin override.

## Scope

- Added `spec.serverless.billing_origin_host` to SIT, UAT, and PROD serverless runtime topology files.
- Kept the public `billing_host` and all existing Worker, canonical DNS, and Cloud Run targets unchanged.

## Verification

- Ruby `YAML.safe_load_file` validation passed for all three serverless topology files.
- Platform boundary validation passed for SIT, UAT, and PROD after rendering these files.
- Terraform, Ansible, and live Cloudflare checks are handled by the companion PRs and deployment workflow.

## Risk / Security / Configuration

- Adds public DNS names that must be created as DNS-only CNAMEs by the platform workflow or IaC/Ansible companion changes.
- No credentials or secret values added.

## Rollback

Revert this PR and the companion PRs, then rerun the serverless workflow with the previous topology revision.

## Related

- Merge this PR first.
- Companion [iac_modules#246](https://github.com/ai-workspace-infra/iac_modules/pull/246), [playbooks#374](https://github.com/ai-workspace-infra/playbooks/pull/374), and [platform-ops-toolkit#420](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/420) consume this field.
