### PR TITLE
fix: retire Billing origin aliases

### DIFF
--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -91,7 +91,6 @@ spec:
     console_host: console-serverless-prod.svc.plus
     accounts_host: accounts-serverless-prod.svc.plus
     billing_host: billing-serverless-prod.svc.plus
-    billing_origin_host: billing-origin-serverless-prod.svc.plus
     frontend_router:
       worker_name: frontend-router-prod
       host: console-serverless-prod.svc.plus

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -91,7 +91,6 @@ spec:
     console_host: console-serverless-sit.onwalk.net
     accounts_host: accounts-serverless-sit.onwalk.net
     billing_host: billing-serverless-sit.onwalk.net
-    billing_origin_host: billing-origin-serverless-sit.onwalk.net
     frontend_router:
       worker_name: frontend-router-sit
       host: console-serverless-sit.onwalk.net

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -91,7 +91,6 @@ spec:
     console_host: console-serverless-uat.onwalk.net
     accounts_host: accounts-serverless-uat.onwalk.net
     billing_host: billing-serverless-uat.onwalk.net
-    billing_origin_host: billing-origin-serverless-uat.onwalk.net
     frontend_router:
       worker_name: frontend-router-uat
       host: console-serverless-uat.onwalk.net


### PR DESCRIPTION
## Outcome
Make the Billing public host and Cloud Run upstream the complete GitOps contract and retire the obsolete DNS-only Origin Rule aliases.

## Issue
- https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32198428682/job/95909479148

## Scope
- Remove billing_origin_host from SIT, UAT, and PROD serverless topology.

## Verification
- UAT topology rendered successfully.
- Platform boundary validation passed with 10 boundaries.

## Risk / Security / Configuration
- Merge after the platform reconciler accepts the optional legacy field.
- No credentials changed.

## Rollback
Revert this PR to restore the compatibility field; this does not recreate DNS by itself.

## Related
- https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/new/bugfix/serverless-boundary-asset-validation