### PR TITLE
fix: bind Frontend Router auth API to edge gateway

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -153,7 +153,7 @@ Consumers must read this GitOps declaration rather than repository-local environ
   contracts (`public`, `authenticated`, `public_uuid`);
 - `spec.cloudflare` defines the Pages project and zone;
 - `spec.serverless.frontend_router` defines the Console Worker Custom Domain, Pages/API origins,
-  static prefixes, and the five SSR Service Bindings;
+  static prefixes, the `api_auth` Edge Gateway Service Binding, and the five SSR Service Bindings;
 - `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;
 - `spec.serverless.edge_gateway` defines `auth`, `admin`, and `core`; `core` owns `/api/*`.
   Its stable `id: core` has the display name **Edge Gateway Router Core** because it also owns the

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -101,6 +101,7 @@ spec:
         - /static/*
         - /assets/*
       bindings:
+        api_auth: edge-gateway-auth-prod
         auth: frontend-ssr-auth-prod
         content: frontend-ssr-content-prod
         console: frontend-ssr-console-prod

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -101,6 +101,7 @@ spec:
         - /static/*
         - /assets/*
       bindings:
+        api_auth: edge-gateway-auth-sit
         auth: frontend-ssr-auth-sit
         content: frontend-ssr-content-sit
         console: frontend-ssr-console-sit

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -101,6 +101,7 @@ spec:
         - /static/*
         - /assets/*
       bindings:
+        api_auth: edge-gateway-auth-uat
         auth: frontend-ssr-auth-uat
         content: frontend-ssr-content-uat
         console: frontend-ssr-console-uat


### PR DESCRIPTION
## Outcome

为 SIT、UAT 和 PROD 的 Frontend Router 声明 `api_auth` Service Binding，指向同环境的 `edge-gateway-auth` Worker。

## Issue

Console 登录 API 不能经过 identity SSR Worker 或 Accounts core Custom Domain；它需要从 Frontend Router 直连独立的认证网关 Worker。

## Scope

- 为三套 serverless topology 增加 `frontend_router.bindings.api_auth`。
- 更新 Serverless 路由配置文档。

## Verification

- `bash scripts/validate-runtime-topologies.sh`
- `git diff --check`

## Risk / Security / Configuration

只新增内部 Worker Service Binding 声明；认证 API 仍由现有 `edge-gateway-auth` 边界处理。

## Rollback

回滚该 GitOps 变更并部署此前的 Frontend Router 版本。

## Related

- Frontend Router implementation: https://github.com/ai-workspace-services/frontend-router/pull/5
