### PR TITLE
feat(topology): declare hybrid as the serverless edge with a backend policy

### DIFF
--- a/topology/prod/hybrid/runtime-topology.yaml
+++ b/topology/prod/hybrid/runtime-topology.yaml
@@ -5,6 +5,19 @@ metadata:
   project: svc.plus
   environment: prod
   mode: hybrid
+# Hybrid is the serverless edge topology with a different backend policy. It is
+# structurally identical to topology/prod/serverless/runtime-topology.yaml and
+# differs only where the two modes genuinely diverge:
+#
+#   1. runtime.mode / metadata.mode           -> hybrid (edge-gateway RUNTIME_MODE var)
+#   2. routing.load-balancer                  -> request-failover instead of dns-only
+#   3. runtime.data                           -> selfhost is the single writer
+#   4. edge_gateway.defaults.failover_methods -> only safe methods may fail over
+#
+# Everything else — Pages project, frontend router, the five SSR boundaries, the
+# three edge-gateway boundaries, Cloud Run URLs, canonical DNS records — is byte
+# for byte the serverless declaration, because hybrid reuses those exact
+# Cloudflare resources rather than standing up a parallel set.
 spec:
   runtime:
     mode: hybrid
@@ -12,14 +25,24 @@ spec:
       dns:
         control_plane: cloudflare-dns
         ttl_seconds: 60
+        # Hybrid serves the public canonical names from the same Cloudflare edge
+        # entry as serverless mode. Failing the whole environment back to the
+        # selfhost full stack is a manual operation: repoint these two records at
+        # the selfhost targets declared under spec.domains. GitOps declares both
+        # targets; it does not switch them.
         canonical_records:
-          console.svc.plus: console-hybrid-prod.svc.plus
-          accounts.svc.plus: accounts-hybrid-prod.svc.plus
+          console.svc.plus: console-serverless-prod.svc.plus
+          accounts.svc.plus: accounts-serverless-prod.svc.plus
       load-balancer:
+        # Request-scoped failover inside the edge-gateway Worker: no health
+        # checks, no state, no control loop — a single request that the selfhost
+        # primary cannot answer is retried against Cloud Run.
         strategy: request-failover
         hybrid:
           primary: selfhost
           fallback: serverless
+      # DNS weight stays fully on selfhost: the split is decided per request at
+      # the edge, not by resolver weighting.
       weight:
         selfhost: 100
         serverless: 0
@@ -36,9 +59,16 @@ spec:
       billing:
         selfhost: vps-full-stack
         serverless: cloud-run
+    # The two data planes never move. Cloud Run is wired to Supabase for its
+    # whole lifetime; the selfhost applications are wired to the VPS-managed
+    # PostgreSQL for theirs. In hybrid mode every mutating request is served by
+    # the selfhost primary, so self-managed-postgresql is the single writer and
+    # Supabase is the async replica. Fallback traffic is restricted to safe
+    # methods (see edge_gateway.defaults.failover_methods) precisely so that a
+    # failover can never produce a second writer.
     data:
-      primary: serverless
-      replica: selfhost
+      primary: selfhost
+      replica: serverless
       providers:
         selfhost: self-managed-postgresql
         serverless: supabase
@@ -62,21 +92,24 @@ spec:
     accounts.svc.plus:
       selfhost: accounts-selfhost-prod.svc.plus
       serverless: accounts-serverless-prod.svc.plus
+  # Hybrid owns no hostnames of its own. Console, accounts, and billing are
+  # served by the shared Cloudflare edge; PostgreSQL and the agent proxy have no
+  # edge presence at all and are reached on the VPS directly.
   public_endpoints:
     console:
-      host: console-hybrid-prod.svc.plus
+      host: console-serverless-prod.svc.plus
       access: public
     accounts:
-      host: accounts-hybrid-prod.svc.plus
+      host: accounts-serverless-prod.svc.plus
       access: authenticated
     billing:
-      host: billing-hybrid-prod.svc.plus
+      host: billing-serverless-prod.svc.plus
       access: authenticated
     postgresql:
-      host: postgresql-hybrid-prod.svc.plus
+      host: postgresql-selfhost-prod.svc.plus
       access: authenticated
     agent-proxy:
-      host: agent-proxy-hybrid-prod.svc.plus
+      host: agent-proxy-selfhost-prod.svc.plus
       access: public_uuid
   cloudflare:
     zone_name: svc.plus
@@ -94,6 +127,25 @@ spec:
     console_host: console-serverless-prod.svc.plus
     accounts_host: accounts-serverless-prod.svc.plus
     billing_host: billing-serverless-prod.svc.plus
+    # Deployed and owned by serverless-orchestrator. Declared here because the
+    # hybrid contract asserts that the frontend is the identical, unmodified
+    # edge chain: a mode flip must never redeploy or reconfigure the frontend.
+    frontend_router:
+      worker_name: frontend-router-prod
+      host: console-serverless-prod.svc.plus
+      pages_origin: https://ai-workspace-portal-prod.pages.dev
+      api_origin: https://accounts-serverless-prod.svc.plus
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        api_auth: edge-gateway-auth-prod
+        auth: frontend-ssr-auth-prod
+        content: frontend-ssr-content-prod
+        console: frontend-ssr-console-prod
+        workspace: frontend-ssr-workspace-prod
+        public: frontend-ssr-public-prod
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -140,14 +192,26 @@ spec:
         fallback_upstream: https://accounts-service-uc.a.run.app
         jwt_issuer: https://accounts-serverless-prod.svc.plus
         timeout_ms: '2500'
+        # The failover leg crosses a database boundary: the primary writes to the
+        # VPS PostgreSQL, the fallback writes to Supabase. Only methods that
+        # cannot mutate state are allowed to cross it. A mutating request that
+        # the primary cannot serve fails as a mutating request should.
+        failover_methods:
+          - GET
+          - HEAD
+          - OPTIONS
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-prod
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-prod
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-prod
-          route: /api/*
+          routes:
+            - /api/*

--- a/topology/sit/hybrid/runtime-topology.yaml
+++ b/topology/sit/hybrid/runtime-topology.yaml
@@ -5,6 +5,19 @@ metadata:
   project: svc.plus
   environment: sit
   mode: hybrid
+# Hybrid is the serverless edge topology with a different backend policy. It is
+# structurally identical to topology/sit/serverless/runtime-topology.yaml and
+# differs only where the two modes genuinely diverge:
+#
+#   1. runtime.mode / metadata.mode           -> hybrid (edge-gateway RUNTIME_MODE var)
+#   2. routing.load-balancer                  -> request-failover instead of dns-only
+#   3. runtime.data                           -> selfhost is the single writer
+#   4. edge_gateway.defaults.failover_methods -> only safe methods may fail over
+#
+# Everything else — Pages project, frontend router, the five SSR boundaries, the
+# three edge-gateway boundaries, Cloud Run URLs, canonical DNS records — is byte
+# for byte the serverless declaration, because hybrid reuses those exact
+# Cloudflare resources rather than standing up a parallel set.
 spec:
   runtime:
     mode: hybrid
@@ -12,14 +25,24 @@ spec:
       dns:
         control_plane: cloudflare-dns
         ttl_seconds: 60
+        # Hybrid serves the public canonical names from the same Cloudflare edge
+        # entry as serverless mode. Failing the whole environment back to the
+        # selfhost full stack is a manual operation: repoint these two records at
+        # the selfhost targets declared under spec.domains. GitOps declares both
+        # targets; it does not switch them.
         canonical_records:
-          console-sit.onwalk.net: console-hybrid-sit.onwalk.net
-          accounts-sit.onwalk.net: accounts-hybrid-sit.onwalk.net
+          console-sit.onwalk.net: console-serverless-sit.onwalk.net
+          accounts-sit.onwalk.net: accounts-serverless-sit.onwalk.net
       load-balancer:
+        # Request-scoped failover inside the edge-gateway Worker: no health
+        # checks, no state, no control loop — a single request that the selfhost
+        # primary cannot answer is retried against Cloud Run.
         strategy: request-failover
         hybrid:
           primary: selfhost
           fallback: serverless
+      # DNS weight stays fully on selfhost: the split is decided per request at
+      # the edge, not by resolver weighting.
       weight:
         selfhost: 100
         serverless: 0
@@ -36,9 +59,16 @@ spec:
       billing:
         selfhost: vps-full-stack
         serverless: cloud-run
+    # The two data planes never move. Cloud Run is wired to Supabase for its
+    # whole lifetime; the selfhost applications are wired to the VPS-managed
+    # PostgreSQL for theirs. In hybrid mode every mutating request is served by
+    # the selfhost primary, so self-managed-postgresql is the single writer and
+    # Supabase is the async replica. Fallback traffic is restricted to safe
+    # methods (see edge_gateway.defaults.failover_methods) precisely so that a
+    # failover can never produce a second writer.
     data:
-      primary: serverless
-      replica: selfhost
+      primary: selfhost
+      replica: serverless
       providers:
         selfhost: self-managed-postgresql
         serverless: supabase
@@ -62,21 +92,24 @@ spec:
     accounts-sit.onwalk.net:
       selfhost: accounts-selfhost-sit.onwalk.net
       serverless: accounts-serverless-sit.onwalk.net
+  # Hybrid owns no hostnames of its own. Console, accounts, and billing are
+  # served by the shared Cloudflare edge; PostgreSQL and the agent proxy have no
+  # edge presence at all and are reached on the VPS directly.
   public_endpoints:
     console:
-      host: console-hybrid-sit.onwalk.net
+      host: console-serverless-sit.onwalk.net
       access: public
     accounts:
-      host: accounts-hybrid-sit.onwalk.net
+      host: accounts-serverless-sit.onwalk.net
       access: authenticated
     billing:
-      host: billing-hybrid-sit.onwalk.net
+      host: billing-serverless-sit.onwalk.net
       access: authenticated
     postgresql:
-      host: postgresql-hybrid-sit.onwalk.net
+      host: postgresql-selfhost-sit.onwalk.net
       access: authenticated
     agent-proxy:
-      host: agent-proxy-hybrid-sit.onwalk.net
+      host: agent-proxy-selfhost-sit.onwalk.net
       access: public_uuid
   cloudflare:
     zone_name: onwalk.net
@@ -94,6 +127,25 @@ spec:
     console_host: console-serverless-sit.onwalk.net
     accounts_host: accounts-serverless-sit.onwalk.net
     billing_host: billing-serverless-sit.onwalk.net
+    # Deployed and owned by serverless-orchestrator. Declared here because the
+    # hybrid contract asserts that the frontend is the identical, unmodified
+    # edge chain: a mode flip must never redeploy or reconfigure the frontend.
+    frontend_router:
+      worker_name: frontend-router-sit
+      host: console-serverless-sit.onwalk.net
+      pages_origin: https://ai-workspace-portal-sit.pages.dev
+      api_origin: https://accounts-serverless-sit.onwalk.net
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        api_auth: edge-gateway-auth-sit
+        auth: frontend-ssr-auth-sit
+        content: frontend-ssr-content-sit
+        console: frontend-ssr-console-sit
+        workspace: frontend-ssr-workspace-sit
+        public: frontend-ssr-public-sit
     cloud_run:
       accounts: https://accounts-service-uc.a.run.app
       content_service: https://content-service-uc.a.run.app
@@ -140,14 +192,26 @@ spec:
         fallback_upstream: https://accounts-service-uc.a.run.app
         jwt_issuer: https://accounts-serverless-sit.onwalk.net
         timeout_ms: '2500'
+        # The failover leg crosses a database boundary: the primary writes to the
+        # VPS PostgreSQL, the fallback writes to Supabase. Only methods that
+        # cannot mutate state are allowed to cross it. A mutating request that
+        # the primary cannot serve fails as a mutating request should.
+        failover_methods:
+          - GET
+          - HEAD
+          - OPTIONS
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-sit
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-sit
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-sit
-          route: /api/*
+          routes:
+            - /api/*

--- a/topology/uat/hybrid/runtime-topology.yaml
+++ b/topology/uat/hybrid/runtime-topology.yaml
@@ -5,6 +5,19 @@ metadata:
   project: svc.plus
   environment: uat
   mode: hybrid
+# Hybrid is the serverless edge topology with a different backend policy. It is
+# structurally identical to topology/uat/serverless/runtime-topology.yaml and
+# differs only where the two modes genuinely diverge:
+#
+#   1. runtime.mode / metadata.mode           -> hybrid (edge-gateway RUNTIME_MODE var)
+#   2. routing.load-balancer                  -> request-failover instead of dns-only
+#   3. runtime.data                           -> selfhost is the single writer
+#   4. edge_gateway.defaults.failover_methods -> only safe methods may fail over
+#
+# Everything else — Pages project, frontend router, the five SSR boundaries, the
+# three edge-gateway boundaries, Cloud Run URLs, canonical DNS records — is byte
+# for byte the serverless declaration, because hybrid reuses those exact
+# Cloudflare resources rather than standing up a parallel set.
 spec:
   runtime:
     mode: hybrid
@@ -12,14 +25,24 @@ spec:
       dns:
         control_plane: cloudflare-dns
         ttl_seconds: 60
+        # Hybrid serves the public canonical names from the same Cloudflare edge
+        # entry as serverless mode. Failing the whole environment back to the
+        # selfhost full stack is a manual operation: repoint these two records at
+        # the console-selfhost-uat / accounts-selfhost-uat targets declared under
+        # spec.domains. GitOps declares both targets; it does not switch them.
         canonical_records:
-          console-uat.onwalk.net: console-hybrid-uat.onwalk.net
-          accounts-uat.onwalk.net: accounts-hybrid-uat.onwalk.net
+          console-uat.onwalk.net: console-serverless-uat.onwalk.net
+          accounts-uat.onwalk.net: accounts-serverless-uat.onwalk.net
       load-balancer:
+        # Request-scoped failover inside the edge-gateway Worker: no health
+        # checks, no state, no control loop — a single request that the selfhost
+        # primary cannot answer is retried against Cloud Run.
         strategy: request-failover
         hybrid:
           primary: selfhost
           fallback: serverless
+      # DNS weight stays fully on selfhost: the split is decided per request at
+      # the edge, not by resolver weighting.
       weight:
         selfhost: 100
         serverless: 0
@@ -36,9 +59,16 @@ spec:
       billing:
         selfhost: vps-full-stack
         serverless: cloud-run
+    # The two data planes never move. Cloud Run is wired to Supabase for its
+    # whole lifetime; the selfhost applications are wired to the VPS-managed
+    # PostgreSQL for theirs. In hybrid mode every mutating request is served by
+    # the selfhost primary, so self-managed-postgresql is the single writer and
+    # Supabase is the async replica. Fallback traffic is restricted to safe
+    # methods (see edge_gateway.defaults.failover_methods) precisely so that a
+    # failover can never produce a second writer.
     data:
-      primary: serverless
-      replica: selfhost
+      primary: selfhost
+      replica: serverless
       providers:
         selfhost: self-managed-postgresql
         serverless: supabase
@@ -62,21 +92,24 @@ spec:
     accounts-uat.onwalk.net:
       selfhost: accounts-selfhost-uat.onwalk.net
       serverless: accounts-serverless-uat.onwalk.net
+  # Hybrid owns no hostnames of its own. Console, accounts, and billing are
+  # served by the shared Cloudflare edge; PostgreSQL and the agent proxy have no
+  # edge presence at all and are reached on the VPS directly.
   public_endpoints:
     console:
-      host: console-hybrid-uat.onwalk.net
+      host: console-serverless-uat.onwalk.net
       access: public
     accounts:
-      host: accounts-hybrid-uat.onwalk.net
+      host: accounts-serverless-uat.onwalk.net
       access: authenticated
     billing:
-      host: billing-hybrid-uat.onwalk.net
+      host: billing-serverless-uat.onwalk.net
       access: authenticated
     postgresql:
-      host: postgresql-hybrid-uat.onwalk.net
+      host: postgresql-selfhost-uat.onwalk.net
       access: authenticated
     agent-proxy:
-      host: agent-proxy-hybrid-uat.onwalk.net
+      host: agent-proxy-selfhost-uat.onwalk.net
       access: public_uuid
   cloudflare:
     zone_name: onwalk.net
@@ -94,10 +127,29 @@ spec:
     console_host: console-serverless-uat.onwalk.net
     accounts_host: accounts-serverless-uat.onwalk.net
     billing_host: billing-serverless-uat.onwalk.net
+    # Deployed and owned by serverless-orchestrator. Declared here because the
+    # hybrid contract asserts that the frontend is the identical, unmodified
+    # edge chain: a mode flip must never redeploy or reconfigure the frontend.
+    frontend_router:
+      worker_name: frontend-router-uat
+      host: console-serverless-uat.onwalk.net
+      pages_origin: https://ai-workspace-portal-uat.pages.dev
+      api_origin: https://accounts-serverless-uat.onwalk.net
+      static_prefixes:
+        - /_next/*
+        - /static/*
+        - /assets/*
+      bindings:
+        api_auth: edge-gateway-auth-uat
+        auth: frontend-ssr-auth-uat
+        content: frontend-ssr-content-uat
+        console: frontend-ssr-console-uat
+        workspace: frontend-ssr-workspace-uat
+        public: frontend-ssr-public-uat
     cloud_run:
-      accounts: https://accounts-service-uc.a.run.app
-      content_service: https://content-service-uc.a.run.app
-      billing_service: https://billing-service-uc.a.run.app
+      accounts: https://uat-accounts-1004637461064.asia-northeast1.run.app
+      content_service: https://uat-content-service-1004637461064.asia-northeast1.run.app
+      billing_service: https://uat-billing-service-1004637461064.asia-northeast1.run.app
     ssr:
       - id: public
         worker_name: frontend-ssr-public-uat
@@ -137,17 +189,29 @@ spec:
     edge_gateway:
       defaults:
         primary_upstream: https://accounts-selfhost-uat.onwalk.net
-        fallback_upstream: https://accounts-service-uc.a.run.app
+        fallback_upstream: https://uat-accounts-1004637461064.asia-northeast1.run.app
         jwt_issuer: https://accounts-serverless-uat.onwalk.net
         timeout_ms: '2500'
+        # The failover leg crosses a database boundary: the primary writes to the
+        # VPS PostgreSQL, the fallback writes to Supabase. Only methods that
+        # cannot mutate state are allowed to cross it. A mutating request that
+        # the primary cannot serve fails as a mutating request should.
+        failover_methods:
+          - GET
+          - HEAD
+          - OPTIONS
       boundaries:
         - id: auth
           worker_name: edge-gateway-auth-uat
-          route: /api/auth/*
+          routes:
+            - /api/auth/*
+            - /api/v1/auth/*
         - id: admin
           worker_name: edge-gateway-admin-uat
-          route: /api/admin/*
+          routes:
+            - /api/admin/*
         - id: core
           display_name: Edge Gateway Router Core
           worker_name: edge-gateway-core-uat
-          route: /api/*
+          routes:
+            - /api/*


### PR DESCRIPTION
## Why

The hybrid declarations had drifted into a stale copy of their serverless siblings:

- scalar `route:` keys instead of routes arrays — `api-auth` was missing `/api/v1/auth/*`, which **failed the contract gate outright**, so hybrid mode had never deployed;
- placeholder Cloud Run URLs (`https://accounts-service-uc.a.run.app`) while serverless carried the real ones — the failover leg pointed at nothing;
- no `frontend_router` block at all, so hybrid declared no frontend;
- `console-hybrid-uat` / `accounts-hybrid-uat` public endpoint hostnames that nothing in any pipeline has ever created.

## What

Hybrid is the serverless edge chain with a different backend policy, so it is now declared that way. Strip the comments and each hybrid file differs from its serverless sibling in **exactly four places**:

| # | Field | Value |
|---|---|---|
| 1 | `runtime.mode` / `metadata.mode` | `hybrid` — this is the edge-gateway `RUNTIME_MODE` var |
| 2 | `routing.load-balancer` | `request-failover` + `hybrid: {primary: selfhost, fallback: serverless}` |
| 3 | `runtime.data` | `primary: selfhost` / `replica: serverless` |
| 4 | `edge_gateway.defaults.failover_methods` | `[GET, HEAD, OPTIONS]` |

```
$ diff <(grep -v '^\s*#' topology/uat/serverless/runtime-topology.yaml | grep -v '^\s*$') \
       <(grep -v '^\s*#' topology/uat/hybrid/runtime-topology.yaml     | grep -v '^\s*$')
```
→ the four deltas above, plus the `postgresql`/`agent-proxy` endpoints, and nothing else.

Everything else is byte for byte identical because hybrid **reuses those exact Cloudflare resources** rather than standing up a parallel set — same Pages project, same `frontend-router-<env>`, same five SSR Workers, same three gateway Workers, same Cloud Run services.

**Hybrid owns no hostname of its own.** Console, accounts, and billing are the shared serverless edge entry; PostgreSQL and the agent proxy have no edge presence at all and are reached on the VPS directly (`*-selfhost-<env>`). The `*-hybrid-*` names are gone.

**The two data planes never move.** Cloud Run stays wired to Supabase; the selfhost applications stay wired to the VPS-managed PostgreSQL. Every mutating request is served by the selfhost primary and failover is restricted to safe methods, so `self-managed-postgresql` is the single writer and a failover can never produce a second one.

**Failing back to the selfhost full stack stays manual.** Both targets are declared under `spec.domains`; nothing in GitOps or in any pipeline switches between them.

`sit` and `prod` are derived from their own serverless siblings by the same mechanical transform, so the three environments cannot drift apart again.

## Verification

Against `platform-ops-toolkit` PR 2:

```
contract validator, sit/uat/prod × serverless/hybrid   6/6 valid, 10 boundaries each
verify_hybrid_contract.sh, sit/uat/prod                3/3 PASS
```

The serverless topologies are **not modified** by this PR.

## Known gap, not introduced here

`sit` and `prod` still carry the placeholder `https://accounts-service-uc.a.run.app` as `fallback_upstream` and in `cloud_run.*`, inherited from their serverless siblings — only `uat` has real Cloud Run URLs. This is a pre-existing gap in those two environments and it bites serverless mode harder than hybrid, since there the placeholder is the *only* upstream. Real values needed before either mode is usable in sit/prod.

## Dependency order

This is **PR 3 of 3** and should merge **last**.

1. [ai-workspace-services/edge-gateway#17](https://github.com/ai-workspace-services/edge-gateway/pull/17) — the Worker honours `failover_methods`
2. [ai-workspace-infra/platform-ops-toolkit#435](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/435) — orchestrator rewrite + the contract gate that reads this declaration
3. **this PR**

Merging this before PR 2 leaves the hybrid contract red — the old validator rejects `public_endpoints.console.host` once the `*-hybrid-*` names are gone. That is the same red it is in on `main` today, so it is not a regression, but there is no reason to sequence it that way. `serverless-orchestrator` and `selfhost-orchestrator` are unaffected in every ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
