### PR TITLE
feat(serverless): declare multi-environment static CDN URLs

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -151,7 +151,7 @@ Consumers must read this GitOps declaration rather than repository-local environ
 - `spec.domains` defines the canonical Console/Accounts aliases;
 - `spec.public_endpoints` defines the five mode-qualified public service entrances and access
   contracts (`public`, `authenticated`, `public_uuid`);
-- `spec.cloudflare` defines the Pages project and zone;
+- `spec.cloudflare` defines the Pages project, zone, and static_cdn_url (direct Pages origin for SIT/UAT, dedicated assets domain for PROD);
 - `spec.serverless.frontend_router` defines the Console Worker Custom Domain, Pages/API origins,
   static prefixes, the `api_auth` Edge Gateway Service Binding, and the five SSR Service Bindings;
 - `spec.serverless.ssr` defines exactly five independently deployable SSR boundaries;

--- a/topology/prod/serverless/runtime-topology.yaml
+++ b/topology/prod/serverless/runtime-topology.yaml
@@ -79,6 +79,7 @@ spec:
     zone_name: svc.plus
     pages_project: ai-workspace-portal-prod
     pages_branch: prod
+    static_cdn_url: https://assets.svc.plus
   vps:
     stack: full-stack
     services:

--- a/topology/sit/serverless/runtime-topology.yaml
+++ b/topology/sit/serverless/runtime-topology.yaml
@@ -79,6 +79,7 @@ spec:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-sit
     pages_branch: sit
+    static_cdn_url: https://ai-workspace-portal-sit.pages.dev
   vps:
     stack: full-stack
     services:

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -79,6 +79,7 @@ spec:
     zone_name: onwalk.net
     pages_project: ai-workspace-portal-uat
     pages_branch: uat
+    static_cdn_url: https://ai-workspace-portal-uat.pages.dev
   vps:
     stack: full-stack
     services:


### PR DESCRIPTION
## Outcome

Declare the `static_cdn_url` property under `spec.cloudflare` across SIT, UAT, and PROD serverless runtime topologies to support direct Pages CDN static asset routing (and dedicated custom assets domain in PROD), bypassing Frontend Router worker invocations.

## Issue

- N/A — Optimization to eliminate Frontend Router static asset request overhead on Cloudflare Serverless edge.

## Scope

- Added `static_cdn_url` under `spec.cloudflare` in `topology/sit/serverless/runtime-topology.yaml` (`https://ai-workspace-portal-sit.pages.dev`).
- Added `static_cdn_url` under `spec.cloudflare` in `topology/uat/serverless/runtime-topology.yaml` (`https://ai-workspace-portal-uat.pages.dev`).
- Added `static_cdn_url` under `spec.cloudflare` in `topology/prod/serverless/runtime-topology.yaml` (`https://assets.svc.plus`).
- Documented `static_cdn_url` in `docs/serverless-edge-routing-config.md`.

## Verification

- `validate_cloudflare_boundaries.py` — passed for SIT, UAT, and PROD runtime topologies.
- `git diff --check` — passed with no trailing whitespace or format issues.

## Risk / Security / Configuration

- None. Declarative extension to Cloudflare topology configuration consumed during Portal SSR boundary and Pages build stages.

## Rollback

Revert this PR.

## Related

- Companion PR: [ai-workspace-services/portal#242](https://github.com/ai-workspace-services/portal/pull/242).
