### PR TITLE
fix: declare the legacy UAT console hostname

### DIFF
--- a/docs/serverless-edge-routing-config.md
+++ b/docs/serverless-edge-routing-config.md
@@ -149,6 +149,9 @@ Consumers must read this GitOps declaration rather than repository-local environ
 
 - `spec.runtime` defines mode, routing, services, and data handover;
 - `spec.domains` defines the canonical Console/Accounts aliases;
+- `spec.serverless.console_aliases` lists extra hostnames that still reach the Console and must
+  therefore stay in the accounts CORS allowlist; it creates no DNS record and takes part in no
+  traffic switch, unlike the canonical aliases above;
 - `spec.public_endpoints` defines the five mode-qualified public service entrances and access
   contracts (`public`, `authenticated`, `public_uuid`);
 - `spec.cloudflare` defines the Pages project, zone, and static_cdn_url (direct Pages origin for SIT/UAT, dedicated assets domain for PROD);

--- a/topology/uat/serverless/runtime-topology.yaml
+++ b/topology/uat/serverless/runtime-topology.yaml
@@ -90,6 +90,13 @@ spec:
     database: self-managed-postgresql
   serverless:
     console_host: console-serverless-uat.onwalk.net
+    # Legacy hostnames that still reach the console. They are outside the
+    # canonical alias contract above (nothing here creates or moves a DNS
+    # record), but a browser still sends whichever hostname the user typed as
+    # the Origin, so accounts must accept them or those logins fail with an
+    # empty 403.
+    console_aliases:
+      - console-cloudflare-uat.onwalk.net
     accounts_host: accounts-serverless-uat.onwalk.net
     billing_host: billing-serverless-uat.onwalk.net
     frontend_router:


### PR DESCRIPTION
配合 platform-ops-toolkit [#439](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/439)（消费 `spec.serverless.console_aliases`）。

## 问题

`https://console-cloudflare-uat.onwalk.net` 至今仍绑在 `frontend-router-uat` 上、仍能正常出页面，但本 topology 里没有它，因此从它推导的 accounts CORS 白名单不含这个 Origin —— 浏览器登录一律被 CORS 中间件回空 body 的 403，UI 显示「登录失败，请稍后再试。」；而不带 Origin 的 curl 探测一切正常，容易误判为链路好的。

同一个 `POST /api/auth/login`，只换 Origin：`console-cloudflare-uat` → 403 空 body；`console-serverless-uat` / `console-uat` / 无 Origin → 404 JSON `{"error":"user_not_found"}`。

## 改动

在 uat 的 `spec.serverless` 下声明：

```yaml
console_aliases:
  - console-cloudflare-uat.onwalk.net
```

只进 CORS 白名单。DNS 调谐读的是 `spec.runtime.routing.dns.canonical_records`，本 PR 未改动，所以不会新增或搬动任何 DNS 记录，也不参与 selfhost↔serverless 切流。sit / prod 没有这类遗留主机名，未改。

`scripts/validate-runtime-topologies.sh` 通过（9 份 topology）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)